### PR TITLE
Fix testListThirdPartyProcesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ selendroid.iws
 .idea/
 *.iml
 
+.gradle/
 gradle/
 gradlew
 gradlew.bat

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
@@ -72,7 +72,7 @@ public class AbstractDeviceTest {
         "1 zygote\n" +
         "23 /system/bin/mediaserver";
     when(
-        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)? shell ps$"))))
+        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)?, shell, ps]$"))))
             .thenReturn(psOutput);
     String expected =
         "PID NAME\n" +


### PR DESCRIPTION
The old regex failed to match [/android-sdk-macosx/platform-tools/adb, shell, ps]