### PR TITLE
Fix test

### DIFF
--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/AbstractDeviceTest.java
@@ -44,17 +44,17 @@ public class AbstractDeviceTest {
       }
     };
   }
-  @Ignore("Build failure: Ignored till the fix is available.")
+
   @Test
   public void testGetCrashLogContents() {
     AbstractDevice device = mock(AbstractDevice.class);
     when(device.getExternalStoragePath()).thenReturn("/storage");
     when(device.getCrashLog()).thenCallRealMethod();
     when(
-        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)? shell ls /storage/$"))))  // The trailing '/' is key
+        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)?, shell, ls, /storage/]$"))))  // The trailing '/' is key
         .thenReturn("some_file\nappcrash.log\nanother_file");
     when(
-        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)? shell cat /storage/appcrash\\.log$"))))
+        device.executeCommandQuietly(argThat(matchesCmdLine(".*adb(\\.exe)?, shell, cat, /storage/appcrash\\.log]$"))))
         .thenReturn("crash log contents");
 
     assertEquals("crash log contents", device.getCrashLog());

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulatorTests.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultAndroidEmulatorTests.java
@@ -33,7 +33,7 @@ public class DefaultAndroidEmulatorTests {
     Assert.assertFalse("Expecting list of avds not to be empty", avds.isEmpty());
   }
 
-  @Ignore("Build failure: Ignored till the fix is available.")
+  @Ignore("Fail. Requires emulator to exist on the system running the test.")
   @Test
   public void testShouldBeAbleToStartEmulator() throws Exception {
     AndroidEmulator emulator =

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultHardwareDeviceTests.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/android/impl/DefaultHardwareDeviceTests.java
@@ -62,7 +62,7 @@ public class DefaultHardwareDeviceTests {
     Assert.assertFalse(installedAPKs.contains(AUT_PACKAGE));
   }
 
-  @Ignore("Build failure: Ignored till the fix is available.")
+  @Ignore("Fail. Requires an active emulator to install the selendroid apk.")
   @Test
   public void testShouldBeAbleToStartSelendroid() throws Exception {
     IDevice device = mock(IDevice.class);

--- a/selendroid-standalone/src/test/java/io/selendroid/standalone/server/e2e/SessionCreationE2ETests.java
+++ b/selendroid-standalone/src/test/java/io/selendroid/standalone/server/e2e/SessionCreationE2ETests.java
@@ -34,19 +34,19 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 public class SessionCreationE2ETests {
   public static final String TEST_APP_ID = "io.selendroid.testapp:0.5.0-SNAPSHOT";
 
-  @Ignore
-  @Test()
+  @Ignore("Fail. Requires an active android emulator")
+  @Test
   public void assertThatSessionCanBeExecutedOnAndroid10Emulator() throws Exception {
     testMethod(SelendroidCapabilities.emulator(DeviceTargetPlatform.ANDROID10, TEST_APP_ID));
   }
 
-  @Ignore
+  @Ignore("Fail. Requires an active android emulator")
   @Test
   public void assertThatSessionCanBeExecutedOnAndroid16Emulator() throws Exception {
     testMethod(SelendroidCapabilities.emulator(DeviceTargetPlatform.ANDROID16, TEST_APP_ID));
   }
 
-  @Ignore
+  @Ignore("Fail. Requires an active android emulator")
   @Test
   public void assertThatSessionCanBeExecutedOnAndroid17Device() throws Exception {
     SelendroidCapabilities capa =


### PR DESCRIPTION
This fixes the last failing non-E2E test. I also added comments to the `@Ignored` tests that explain why they're skipped. Tests that require starting up an android emulator are incredibly slow and flaky. I don't plan to fix these tests. The Android emulator tests will need to be rewritten once our Jenkins CI is setup.

Also now that Selendroid Standalone is no longer an Android gradle project, I've had to use [`IntelliJ IDEA 14 CE`](https://www.jetbrains.com/idea/download/) to work on the code and run tests from the IDE.

Fix #1

![selendroid_test_results](https://cloud.githubusercontent.com/assets/1173057/10683071/978ea316-790b-11e5-9865-30499d39b25d.png)