### PR TITLE
uiautomator2 multiple deivce issue

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -112,13 +112,29 @@ class UiAutomator2Server {
     //using 3rd party module called 'adbKit' for time being as using 'appium-adb'
     //facing IllegalStateException: UiAutomation not connected exception
     //https://github.com/appium/appium-uiautomator2-driver/issues/19
-    this.startSessionUsingAdbkit();
+
+    if (caps.deviceUDID) {
+      this.startSessionOnSpecificDeviceUsingAdbKit(caps.deviceUDID);
+    } else {
+      this.startSessionUsingAdbkit();
+    }
+
     logger.info('Waiting for UiAutomator2 to be online...');
     // wait 20s for UiAutomator2 to be online
     await retryInterval(20, 1000, async () => {
       await this.jwproxy.command('/status', 'GET');
     });
     await this.jwproxy.command('/session', 'POST', {desiredCapabilities: caps});
+  }
+
+  async startSessionOnSpecificDeviceUsingAdbKit (deviceUDID) {
+    Promise.try(function (){
+      logger.info(`running command...\n adb -s ${deviceUDID} shell am instrument -w io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner... `);
+      client.shell(deviceUDID, "am instrument -w io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner");
+    })
+      .catch(function (err) {
+        logger.error('Something went wrong while executing instrument test:', err.stack);
+      });
   }
 
   async startSessionUsingAdbkit () {


### PR DESCRIPTION
Hello.

I had issue that whenever I run test on multiple device separately(different test script), one of my devices which ran in first uiautomator2 has been killed.

Here is my setting.
appium version : 1.6.2 using uiautomator2
test environment : two devices attached on one PC, two appium server running on two different port

I noticed that below command sent to all my devices. 
`2016-12-06 14:28:24:842 - info: [UiAutomator2] running command...
 adb shell am instrument -w io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner... 
2016-12-06 14:28:24:843 - info: [UiAutomator2] running command...
 adb shell am instrument -w io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner... `

I am not sure about the purpose of send command to all devices.
So I fixed to send command on specific device when capabilities udid has value.

please review my pull request :) 
Thank you!
