### PR TITLE
Refactor

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -64,7 +64,7 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/element/[^/]+/enabled')],
   ['GET', new RegExp('^/session/[^/]+/element/[^/]+/selected')],
   ['GET', new RegExp('^/session/[^/]+/element/[^/]+/displayed')],
-  ['GET', new RegExp('^/session/[^/]')],
+  ['GET', new RegExp('^/session/(?!.*\/)')],
   ['POST', new RegExp('^/session/[^/]+/keys')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/hide_keyboard')]
 ];

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -7,9 +7,9 @@ import crypto from 'crypto';
 /**
  * UI2_VER, SERVER_DOWNLOAD_SHA512, SERVER_TEST_DOWNLOAD_SHA512 should be updated for every appium-uiautomator2-server release.
  */
-const UI2_VER = "v0.0.9";
-const SERVER_DOWNLOAD_SHA512 = "e02f621db00d610791d9b7e29740933ce6874ed3f56eaac51122714d3ccab596190773e30f0d8003b7d3dd57ef8f5cc562e08617202beef39cd479ccf35746dc";
-const SERVER_TEST_DOWNLOAD_SHA512 = "8be1f72c292a113f5473428dffeb442b68576de092dacd0277331d692e2f143f0ffe46446e946e20ef07142086ff61e510d9011085c7b77aff2ef2bd5e1f8a67";
+const UI2_VER = "v0.1.0";
+const SERVER_DOWNLOAD_SHA512 = "7fc9ff4759b7e10ac592c1de4790f2bbdfeb567beaae3a6dfaccbfce4cfd993ddb81d3658af16c171207d4d6e1373e20233d70e2e01a2fea0ec0c6ea460d0c8b";
+const SERVER_TEST_DOWNLOAD_SHA512 = "94facd9c92a60b6636b0673d938c6f5bcd8afa471916a1e249fb97acba92a1b9d89cee286e61ab21ad96bf98295c339832833062b888e8e2a7a2dac0326737a9";
 
 const UI2_SERVER_DOWNLOAD_CDNURL = process.env.npm_config_uiautomator2_driver_cdnurl ||
                                    process.env.UIAUTOMATOR2_DRIVER_CDNURL ||

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -164,7 +164,7 @@ class UiAutomator2Server {
 
   async killUiAutomatorOnDevice () {
     try {
-      await this.adb.killProcessesByName('io.appium.uiautomator2.server');
+      await this.adb.forceStop('io.appium.uiautomator2.server');
     } catch (ignore) {
       logger.info("Unable to kill the io.appium.uiautomator2.server process, assuming it is already killed");
     }


### PR DESCRIPTION
- Updated

    - to use force stop in `killUiAutomatorOnDevice()`
    - ui2 server version and SHA hash to `v0.1.0`
    - regex to include only `session/:sessionId`
