### PR TITLE
Upgrade portscanner package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.10.2",
     "lodash": "^3.10.1",
-    "portscanner": "1.1.0",
+    "portscanner": "2.1.1",
     "request-promise": "^4.1.1",
     "source-map-support": "^0.3.2",
     "teen_process": "^1.3.1",


### PR DESCRIPTION
`portscanner` 1.1.0 is deprecated. In an effort to minimize the production install warnings, upgrade (the breaking change in `portscanner` is also in 1.1.0, which is why it is deprecated).