### PR TITLE
Fix fail "driver.removeApp(bundleId)"

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -67,7 +67,8 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/(?!.*\/)')],
   ['POST', new RegExp('^/session/[^/]+/keys')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/hide_keyboard')],
-  ['POST', new RegExp('^/session/[^/]+/log')]
+  ['POST', new RegExp('^/session/[^/]+/log')],
+  ['POST', new RegExp('^/session/[^/]+/appium/device/remove_app')]
 ];
 
 


### PR DESCRIPTION
When executing driver.removeApp (bundleId), the following error occurs.

```
[HTTP] --> POST /wd/hub/session/d8621726-4bb6-49fe-9c9c-536868af1f4e/appium/device/remove_app {"bundleId":"xxxxxxxxxxxxxxxxxxxxxxxx"}
[MJSONWP] Driver proxy active, passing request on via HTTP proxy
[debug] [JSONWP Proxy] Proxying [POST /wd/hub/session/d8621726-4bb6-49fe-9c9c-536868af1f4e/appium/device/remove_app] to [POST http://localhost:8200/wd/hub/session/cfbf5cdf-9c69-4722-aebf-04d202c542d8/appium/device/remove_app] with body: {"bundleId":"xxxxxxxxxxxxxxxxxxxxxxxx"}
[MJSONWP] Encountered internal error running command: Error: Could not proxy. Proxy error: Could not proxy command to remote server. Original error: 404 - undefined
    at doJwpProxy$ (../../../lib/mjsonwp/mjsonwp.js:342:13)
    at tryCatch (/Users/hshiraka/.nodebrew/node/v7.4.0/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/hshiraka/.nodebrew/node/v7.4.0/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/hshiraka/.nodebrew/node/v7.4.0/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/hshiraka/.nodebrew/node/v7.4.0/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
[HTTP] <-- POST /wd/hub/session/d8621726-4bb6-49fe-9c9c-536868af1f4e/appium/device/remove_app 500 25 ms - 274
```

So avoid the problem, I add 'remove_app' url to NO_PROXY list.