### PR TITLE
Implement reboot option

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -141,6 +141,10 @@ class AndroidUiautomator2Driver extends BaseDriver {
       };
       _.defaults(this.opts, defaultOpts);
 
+      if (this.opts.reboot) {
+        this.setAvdFromCapabilities(caps);
+        this.addWipeDataToAvdArgs();
+      }
 
       if (this.opts.app) {
         // find and copy, or download and unzip an app url or path
@@ -166,6 +170,29 @@ class AndroidUiautomator2Driver extends BaseDriver {
   get driverData () {
     // TODO fille out resource info here
     return {};
+  }
+
+  setAvdFromCapabilities (caps) {
+    if (this.opts.avd) {
+      logger.info('avd name defined, ignoring device name and platform version');
+    } else {
+      if (!caps.deviceName) {
+        logger.errorAndThrow('avd or deviceName should be specified when reboot option is enables');
+      }
+      if (!caps.platformVersion) {
+        logger.errorAndThrow('avd or platformVersion should be specified when reboot option is enabled');
+      }
+      let avdDevice = caps.deviceName.replace(/[^a-zA-Z0-9_.]/g, "-");
+      this.opts.avd = `${avdDevice}__${caps.platformVersion}`;
+    }
+  }
+
+  addWipeDataToAvdArgs () {
+    if (!this.opts.avdArgs) {
+      this.opts.avdArgs = '-wipe-data';
+    } else  if (this.opts.avdArgs.toLowerCase().indexOf("-wipe-data") === -1) {
+      this.opts.avdArgs += ' -wipe-data';
+    }
   }
 
   async startUiAutomator2Session () {
@@ -344,6 +371,11 @@ class AndroidUiautomator2Driver extends BaseDriver {
         await this.adb.uninstallApk(this.opts.appPackage);
       }
       await this.adb.stopLogcat();
+      if (this.opts.reboot) {
+        let avdName = this.opts.avd.replace('@', '');
+        logger.debug(`closing emulator '${avdName}'`);
+        await this.adb.killEmulator(avdName);
+      }
     }
     await super.deleteSession();
     if (this.opts.systemPort !== undefined) {


### PR DESCRIPTION
The below document says if `reboot` option is true, reboot emulator after each session and kill it at the end.
https://github.com/appium/appium/blob/v1.6.3/docs/en/writing-running-appium/server-args.md

But actually it works only when using appium-android-driver.
So I implemented the reboot option with reference to the implementation of appium-android-driver.