### PR TITLE
Use `adb shell am instrument` if androidCoverage is given

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -354,18 +354,26 @@ class AndroidUiautomator2Driver extends BaseDriver {
     logger.info(`UiAutomator2 did not start the activity we were waiting for, ` +
         `'${appWaitPackage}/${appWaitActivity}'. ` +
         `Starting it ourselves`);
-    await this.adb.startApp({
-      pkg: this.opts.appPackage,
-      activity: this.opts.appActivity,
-      action: this.opts.intentAction,
-      category: this.opts.intentCategory,
-      flags: this.opts.intentFlags,
-      waitPkg: this.opts.appWaitPackage,
-      waitActivity: this.opts.appWaitActivity,
-      optionalIntentArguments: this.opts.optionalIntentArguments,
-      stopApp: !this.opts.dontStopAppOnReset,
-      retry: false
-    });
+
+    if (this.caps.androidCoverage) {
+      logger.info(`androidCoverage is configured. ` +
+        ` Starting instrumentation of '${this.caps.androidCoverage}'...`);
+      await this.adb.androidCoverage(this.caps.androidCoverage, appWaitPackage, appWaitActivity);
+    } else {
+      await this.adb.startApp({
+        pkg: this.opts.appPackage,
+        activity: this.opts.appActivity,
+        action: this.opts.intentAction,
+        category: this.opts.intentCategory,
+        flags: this.opts.intentFlags,
+        waitPkg: this.opts.appWaitPackage,
+        waitActivity: this.opts.appWaitActivity,
+        optionalIntentArguments: this.opts.optionalIntentArguments,
+        stopApp: !this.opts.dontStopAppOnReset,
+        retry: false
+      });
+    }
+    
   }
 
   async deleteSession () {
@@ -384,6 +392,17 @@ class AndroidUiautomator2Driver extends BaseDriver {
           this.defaultIME) {
         logger.debug(`Resetting IME to '${this.defaultIME}'`);
         await this.adb.setIME(this.defaultIME);
+      }
+      if (this.caps.androidCoverage) {
+        logger.info('Shutting down the adb process of instrumentation...');
+        await this.adb.endAndroidCoverage();
+        // Use this broadcast intent to notify it's time to dump coverage to file
+        if (this.caps.androidCoverageEndIntent) {
+          logger.info(`Sending intent broadcast '${this.caps.androidCoverageEndIntent}' at the end of instrumenting.`);
+          await this.adb.broadcast(this.caps.androidCoverageEndIntent);
+        } else {
+          logger.warn('No androidCoverageEndIntent is configured in caps. Possibly you cannot get coverage file.');
+        }
       }
       if (this.opts.appPackage) {
         await this.adb.forceStop(this.opts.appPackage);


### PR DESCRIPTION
## Goal of this PR
Enable UiAutomator2-driver to launch instrumentation
## Fix Issue 
https://github.com/appium/appium/issues/7317
## Other Todos
In order to let users know how to use, later I will make a new PR to appium/appium on the documentation.
