### PR TITLE
Save default IME so we can restore

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -247,7 +247,8 @@ class AndroidUiautomator2Driver extends BaseDriver {
 
     // start an avd, set the language/locale, pick an emulator, etc...
     // TODO with multiple devices we'll need to parameterize this
-    await helpers.initDevice(this.adb, this.opts);
+    this.defaultIME = await helpers.initDevice(this.adb, this.opts);
+
     // Further prepare the device by forwarding the UiAutomator2 port
     logger.debug(`Forwarding UiAutomator2 Server port ${DEVICE_PORT} to ${this.opts.systemPort}`);
     await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
@@ -402,8 +403,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
     this.jwpProxyActive = false;
 
     if (this.adb) {
-      if (this.opts.unicodeKeyboard && this.opts.resetKeyboard &&
-          this.defaultIME) {
+      if (this.opts.unicodeKeyboard && this.opts.resetKeyboard && this.defaultIME) {
         logger.debug(`Resetting IME to '${this.defaultIME}'`);
         try {
           await this.adb.setIME(this.defaultIME);

--- a/test/functional/commands/keyboard/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard/keyboard-e2e-specs.js
@@ -5,6 +5,7 @@ import B from 'bluebird';
 import { retryInterval } from 'asyncbox';
 import { APIDEMOS_CAPS } from '../../desired';
 import { initDriver } from '../../helpers/session';
+import ADB from 'appium-adb';
 
 
 chai.should();
@@ -203,12 +204,23 @@ describe('keyboard', function () {
   });
 
   describe('unicode', function () {
+    let adb = new ADB();
+    let initialIME;
     let driver;
     before(async function () {
+      // save the initial ime so we can make sure it is restored
+      initialIME = await adb.defaultIME();
+      initialIME.should.not.eql('io.appium.android.ime/.UnicodeIME');
+
       driver = await initDriver(defaultUnicodeCaps);
     });
     after(async function () {
       await driver.deleteSession();
+
+      // make sure the IME has been restored
+      let ime = await adb.defaultIME();
+      ime.should.eql(initialIME);
+      ime.should.not.eql('io.appium.android.ime/.UnicodeIME');
     });
 
     describe('editing a text field', function () {


### PR DESCRIPTION
Save the IME that is in use before switching to Appium's Unicode keyboard. Analogous to https://github.com/appium/appium-android-driver/blob/master/lib/driver.js#L224

Fixes https://github.com/appium/appium/issues/8755