### PR TITLE
Add default mocha opts

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--timeout 640000
+--compilers js:babel-core/register


### PR DESCRIPTION
* This one file sets the default flags for calls to mocha
* Adding `--compilers js:babel-core/register` allows you to run mocha tests directly without doing a gulp transpile (mocha transpiles the source for you)
* So instead of `gulp transpile && mocha -t 64000 build/test/path/to/specs.js` you can just run `mocha test/path/to/specs.js`
* Also, by adding the `--watch` flag to mocha, it transpiles the code on-the-fly so you don't have to run an entire transpilation every time you edit a `lib/` or `test/` JS file