### PR TITLE
Add cap to stop animations on instrumentation

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -23,6 +23,9 @@ let uiautomatorCapConstraints = {
   uiautomator2ServerInstallTimeout: {
     isNumber: true
   },
+  disableWindowAnimation: {
+    isBoolean: true
+  },
 };
 
 let desiredCapConstraints = {};

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -305,6 +305,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
       tmpDir: this.opts.tmpDir,
       appPackage: this.opts.appPackage,
       appActivity: this.opts.appActivity,
+      disableWindowAnimation: !!this.opts.disableWindowAnimation,
     });
     this.proxyReqRes = this.uiautomator2.proxyReqRes.bind(this.uiautomator2);
 

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -31,9 +31,9 @@ class UiAutomator2Server {
   /**
    * Installs the apks on to the device or emulator.
    *
-   * @param {number} installRetries - The count of installation retries
+   * @param {number} installTimeout - Installation timeout
    */
-  async installServerApk (installRetries) {
+  async installServerApk (installTimeout = SERVER_INSTALL_RETRIES * 1000) {
     const serverApkInfo = await this.adb.getApkInfo(apkPath);
     const apkPackage = serverApkInfo.name;
     if (!apkPackage) {
@@ -56,13 +56,13 @@ class UiAutomator2Server {
     }
 
     if (!isApkInstalled) {
-      await this.signAndInstall(apkPath, apkPackage);
+      await this.signAndInstall(apkPath, apkPackage, installTimeout);
     }
     if (!isTestApkInstalled) {
-      await this.signAndInstall(testApkPath, testApkPackage, true);
+      await this.signAndInstall(testApkPath, testApkPackage, installTimeout, true);
     }
 
-    let retries = getRetries('Server install', installRetries, SERVER_INSTALL_RETRIES);
+    let retries = getRetries('Server install', installTimeout, SERVER_INSTALL_RETRIES);
 
     logger.debug(`Waiting up to ${retries * 1000}ms for instrumentation '${INSTRUMENTATION_TARGET}' to be available`);
     let output;
@@ -104,9 +104,9 @@ class UiAutomator2Server {
     }
   }
 
-  async signAndInstall (apk, apkPackage, test = false) {
+  async signAndInstall (apk, apkPackage, timeout = SERVER_INSTALL_RETRIES * 1000, test = false) {
     await this.checkAndSignCert(apk, apkPackage);
-    await this.adb.install(apk);
+    await this.adb.install(apk, true, timeout);
     logger.info(`Installed UiAutomator2 server${test ? ' test' : ''} apk`);
   }
 

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -4,9 +4,10 @@ import logger from './logger';
 import { UI2_SERVER_APK_PATH as apkPath, UI2_TEST_APK_PATH as testApkPath, UI2_VER} from './installer';
 import adbkit from 'adbkit';
 import { getRetries } from './utils';
+import { util } from 'appium-support';
 
 
-const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort'];
+const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'disableWindowAnimation'];
 const SERVER_LAUNCH_RETRIES = 20;
 const SERVER_INSTALL_RETRIES = 20;
 const INSTRUMENTATION_TARGET = 'io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner';
@@ -14,7 +15,7 @@ const INSTRUMENTATION_TARGET = 'io.appium.uiautomator2.server.test/android.suppo
 class UiAutomator2Server {
   constructor (opts = {}) {
     for (let req of REQD_PARAMS) {
-      if (!opts || !opts[req]) {
+      if (!opts || !util.hasValue(opts[req])) {
         throw new Error(`Option '${req}' is required!`);
       }
       this[req] = opts[req];
@@ -141,8 +142,12 @@ class UiAutomator2Server {
   }
 
   async startSessionUsingAdbKit (deviceUDID) {
-    logger.info(`Running command: 'adb -s ${deviceUDID} shell am instrument -w ${INSTRUMENTATION_TARGET}'`);
-    this.client.shell(deviceUDID, `am instrument -w ${INSTRUMENTATION_TARGET}`)
+    let cmd = `am instrument -w ${INSTRUMENTATION_TARGET}`;
+    if (this.disableWindowAnimation) {
+      cmd = `${cmd} --no-window-animation`;
+    }
+    logger.info(`Running command: 'adb -s ${deviceUDID} shell ${cmd}'`);
+    this.client.shell(deviceUDID, cmd)
       .then(adbkit.util.readAll) // eslint-disable-line promise/prefer-await-to-then
       .then(function (output) { // eslint-disable-line promise/prefer-await-to-then
         for (let line of output.toString().split('\n')) {

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 
 const uiautomator2ServerLaunchTimeout = process.env.TRAVIS ? 60000 : 20000;
-const uiautomator2ServerInstallTimeout = process.env.TRAVIS ? 30000 : 20000;
+const uiautomator2ServerInstallTimeout = process.env.TRAVIS ? 120000 : 20000;
 
 const GENERIC_CAPS = {
   deviceName: 'Android',

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -15,6 +15,7 @@ const APIDEMOS_CAPS = _.defaults({
   app: require.resolve('android-apidemos'),
   appPackage: 'io.appium.android.apis',
   appActivity: 'io.appium.android.apis.ApiDemos',
+  disableWindowAnimation: true,
 }, GENERIC_CAPS);
 
 const GPS_DEMO_CAPS = _.defaults({


### PR DESCRIPTION
New cap `disableWindowAnimation` which disables animations (using `--no-window-animation` flag) on instrumentation process.

See https://github.com/appium/appium/issues/5400