### PR TITLE
Do not proxy getting app strings

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -69,7 +69,8 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/appium/device/hide_keyboard')],
   ['POST', new RegExp('^/session/[^/]+/log')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/remove_app')],
-  ['GET', new RegExp('^/session/[^/]+/appium/device/is_keyboard_shown')]
+  ['GET', new RegExp('^/session/[^/]+/appium/device/is_keyboard_shown')],
+  ['POST', new RegExp('^/session/[^/]+/appium/app/strings')],
 ];
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "android-apidemos": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/android-apidemos/-/android-apidemos-2.1.1.tgz",
-      "integrity": "sha512-4u6Oxx1s+Pi/5mn86E0oYGNV3WjViZE/Z66/gnC+d3rwpRuHys9+Bu9PzbhLym6dx0vEPA80YhyGjkEYu3iQBQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/android-apidemos/-/android-apidemos-2.1.2.tgz",
+      "integrity": "sha1-bTTGBs0DyNTea1zfLJzak4bF50g=",
       "dev": true
     },
     "ansi": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test"
   ],
   "devDependencies": {
-    "android-apidemos": "^2.1.0",
+    "android-apidemos": "^2.1.2",
     "appium-gulp-plugins": "^2.1.4",
     "appium-test-support": "0.4.0",
     "babel-eslint": "^7.1.1",

--- a/test/functional/commands/general-e2e-specs.js
+++ b/test/functional/commands/general-e2e-specs.js
@@ -68,14 +68,4 @@ describe('general', function () {
       appActivity.should.equal(startAppActivity);
     });
   });
-  describe('getStrings', function () {
-    it('should return app strings', async () => {
-      let strings = await driver.getStrings('en');
-      strings.activity_sample_code.should.equal('API Demos');
-    });
-    it('should return app strings for the device language', async () => {
-      let strings = await driver.getStrings();
-      strings.activity_sample_code.should.equal('API Demos');
-    });
-  });
 });

--- a/test/functional/commands/language-e2e-specs.js
+++ b/test/functional/commands/language-e2e-specs.js
@@ -1,0 +1,49 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import ADB from 'appium-adb';
+import { initDriver } from '../helpers/session';
+import { APIDEMOS_CAPS } from '../desired';
+import { androidHelpers } from 'appium-android-driver';
+import { getLocale } from '../helpers/helpers';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('Localization - locale @skip-ci @skip-real-device', function () {
+  let initialLocale;
+
+  before(async function () {
+    // restarting doesn't work on Android 7+
+    let adb = new ADB();
+    if (await adb.getApiLevel() > 23) return this.skip(); //eslint-disable-line curly
+
+    initialLocale = await getLocale(adb);
+  });
+
+  let driver;
+  after(async function () {
+    if (driver) {
+      await androidHelpers.ensureDeviceLocale(driver.adb, null, initialLocale);
+
+      await driver.deleteSession();
+    }
+  });
+
+  it('should start as FR', async () => {
+    let frCaps = Object.assign({}, APIDEMOS_CAPS, {
+      language: 'fr',
+      locale: 'FR',
+    });
+    driver = await initDriver(frCaps);
+    await getLocale(driver.adb).should.eventually.equal('fr-FR');
+  });
+  it('should start as US', async () => {
+    let usCaps = Object.assign({}, APIDEMOS_CAPS, {
+      language: 'en',
+      locale: 'US',
+    });
+    driver = await initDriver(usCaps);
+    await getLocale(driver.adb).should.eventually.equal('en-US');
+  });
+});

--- a/test/functional/commands/strings-e2e-specs.js
+++ b/test/functional/commands/strings-e2e-specs.js
@@ -1,8 +1,11 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { APIDEMOS_CAPS } from '../desired';
+import ADB from 'appium-adb';
 import { initDriver } from '../helpers/session';
+import { getLocale } from '../helpers/helpers';
 import _ from 'lodash';
+import { androidHelpers } from 'appium-android-driver';
 
 
 chai.should();
@@ -31,8 +34,20 @@ describe('strings', function () {
   });
 
   describe('device language', function () {
+    let initialLocale;
+    before(async function () {
+      // restarting doesn't work on Android 7+
+      let adb = new ADB();
+      if (await adb.getApiLevel() > 23) return this.skip(); //eslint-disable-line curly
+
+      initialLocale = await getLocale(adb);
+    });
     afterEach(async function () {
-      await driver.deleteSession();
+      if (driver) {
+        await androidHelpers.ensureDeviceLocale(driver.adb, null, initialLocale);
+
+        await driver.deleteSession();
+      }
     });
 
     it('should return app strings with default locale/language', async function () {

--- a/test/functional/commands/strings-e2e-specs.js
+++ b/test/functional/commands/strings-e2e-specs.js
@@ -1,0 +1,54 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { APIDEMOS_CAPS } from '../desired';
+import { initDriver } from '../helpers/session';
+import _ from 'lodash';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('strings', function () {
+  let driver;
+
+  describe('specific language', function () {
+    before(async () => {
+      driver = await initDriver(APIDEMOS_CAPS);
+    });
+    after(async function () {
+      await driver.deleteSession();
+    });
+
+    it('should return app strings', async function () {
+      let strings = await driver.getStrings('en');
+      strings.hello_world.should.equal('<b>Hello, <i>World!</i></b>');
+    });
+
+    it('should return app strings for different language', async function () {
+      let strings = await driver.getStrings('fr');
+      strings.hello_world.should.equal('<b>Bonjour, <i>Monde!</i></b>');
+    });
+  });
+
+  describe('device language', function () {
+    afterEach(async function () {
+      await driver.deleteSession();
+    });
+
+    it('should return app strings with default locale/language', async function () {
+      driver = await initDriver(APIDEMOS_CAPS);
+
+      let strings = await driver.getStrings();
+      strings.hello_world.should.equal('<b>Hello, <i>World!</i></b>');
+    });
+    it('should return app strings when language/locale set', async function () {
+      driver = await initDriver(_.defaults({
+        language: 'fr',
+        locale: 'CA',
+      }, APIDEMOS_CAPS));
+
+      let strings = await driver.getStrings();
+      strings.hello_world.should.equal('<b>Bonjour, <i>Monde!</i></b>');
+    });
+  });
+});

--- a/test/functional/commands/strings-e2e-specs.js
+++ b/test/functional/commands/strings-e2e-specs.js
@@ -56,7 +56,7 @@ describe('strings', function () {
       let strings = await driver.getStrings();
       strings.hello_world.should.equal('<b>Hello, <i>World!</i></b>');
     });
-    it('should return app strings when language/locale set', async function () {
+    it('should return app strings when language/locale set @skip-ci', async function () {
       driver = await initDriver(_.defaults({
         language: 'fr',
         locale: 'CA',

--- a/test/functional/helpers/helpers.js
+++ b/test/functional/helpers/helpers.js
@@ -1,0 +1,9 @@
+async function getLocale (adb) {
+  if (await adb.getApiLevel() < 23) {
+    return await adb.getDeviceCountry();
+  } else {
+    return await adb.getDeviceLocale();
+  }
+}
+
+export { getLocale };


### PR DESCRIPTION
The driver has the ability to get the strings from the device, so don't proxy the request. This seems to fix https://github.com/appium/appium/issues/8930, though setting the locale/language is flakey so the tests are quarantined in Travis.