### PR TITLE
Add `/log/types` endpoint to NO_PROXY

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -68,6 +68,7 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/keys')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/hide_keyboard')],
   ['POST', new RegExp('^/session/[^/]+/log')],
+  ['GET', new RegExp('^/session/[^/]+/log/types')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/remove_app')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/is_keyboard_shown')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/strings')],


### PR DESCRIPTION
`/log/types` endpoint implemented in `appium-android-driver` and should not  be proxied to `appium-uiautomator2-server`.