### PR TITLE
add some commands we should set as no-proxy

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -43,6 +43,7 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/appium/app/close')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/launch')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/pull_file')],
+  ['POST', new RegExp('^/session/[^/]+/appium/device/pull_folder')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/push_file')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/reset')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/background')],
@@ -71,10 +72,18 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/log/types')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/remove_app')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/install_app')],
+  ['GET', new RegExp('^/session/[^/]+/appium/device/current_package')],
+  ['GET', new RegExp('^/session/[^/]+/appium/device/display_density')],
+  ['GET', new RegExp('^/session/[^/]+/appium/device/system_bars')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/is_keyboard_shown')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/strings')],
+  ['POST', new RegExp('^/session/[^/]+/appium/performanceData/types')],
+  ['GET', new RegExp('^/session/[^/]+/ime/available_engines')],
+  ['GET', new RegExp('^/session/[^/]+/ime/active_engine')],
+  ['GET', new RegExp('^/session/[^/]+/ime/activated')],
+  ['POST', new RegExp('^/session/[^/]+/ime/deactivate')],
+  ['POST', new RegExp('^/session/[^/]+/ime/activate')],
 ];
-
 
 // This is a set of methods and paths that we never want to proxy to Chromedriver.
 const CHROME_NO_PROXY = [

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -70,6 +70,7 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/log')],
   ['GET', new RegExp('^/session/[^/]+/log/types')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/remove_app')],
+  ['POST', new RegExp('^/session/[^/]+/appium/device/install_app')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/is_keyboard_shown')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/strings')],
 ];

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -77,6 +77,7 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/appium/device/system_bars')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/is_keyboard_shown')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/strings')],
+  ['POST', new RegExp('^/session/[^/]+/appium/getPerformanceData')],
   ['POST', new RegExp('^/session/[^/]+/appium/performanceData/types')],
   ['GET', new RegExp('^/session/[^/]+/ime/available_engines')],
   ['GET', new RegExp('^/session/[^/]+/ime/active_engine')],


### PR DESCRIPTION
When I run tests fully in `ruby_lib` against `uiautomator2`, `v0.7.0` driver, I found some commands we should set no-proxy.

The following is an example of `install_app`.

```
[MJSONWP] Driver proxy active, passing request on via HTTP proxy
[debug] [JSONWP Proxy] Proxying [POST /wd/hub/session/c98fdf58-4ec8-43e6-8676-6b2eba2b97c4/appium/device/install_app] to [POST http://localhost:8200/wd/hub/session/dde9b411-1457-4795-86a0-c6fbe046a1b7/appium/device/install_app] with body: {"appPath":"/Users/kazucocoa/GitHub/ruby_lib/test_apps/api.apk"}
[MJSONWP] Encountered internal error running command: Error: Could not proxy. Proxy error: Could not proxy command to remote server. Original error: 404 - undefined
    at doJwpProxy$ (/Users/kazucocoa/GitHub/appium/node_modules/appium-base-driver/lib/mjsonwp/mjsonwp.js:384:13)
    at tryCatch (/Users/kazucocoa/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/kazucocoa/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/kazucocoa/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/kazucocoa/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
[HTTP] <-- POST /wd/hub/session/c98fdf58-4ec8-43e6-8676-6b2eba2b97c4/appium/device/install_app 500 42 ms - 274
```

So, I've added `install_app` into `NO_PROXY` in this PR and it works fine like the below logs.

```
[debug] [ADB] Getting install status for io.appium.android.apis
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running '/Users/kazucocoa/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","CB5A22LZ79","shell","pm","list","packages","io.appium.android.apis"]
[debug] [ADB] App is not installed
[AndroidDriver] Apk is not yet installed
[AndroidDriver] installing apk from remote
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running '/Users/kazucocoa/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","CB5A22LZ79","shell","mkdir","-p","/data/local/tmp"]
[AndroidDriver] Clearing out any existing remote apks with the same hash
[debug] [AndroidDriver] Removing any old apks
[debug] [AndroidDriver] Except ["ccc4d5202221a2854897d2f45cf8928f"]
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running '/Users/kazucocoa/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","CB5A22LZ79","shell","ls","/data/local/tmp/*.apk"]
[debug] [ADB] Uninstalling io.appium.android.apis
[debug] [ADB] Getting install status for io.appium.android.apis
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running '/Users/kazucocoa/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","CB5A22LZ79","shell","pm","list","packages","io.appium.android.apis"]
[debug] [ADB] App is not installed
[ADB] io.appium.android.apis was not uninstalled, because it was not present on the device
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running '/Users/kazucocoa/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","CB5A22LZ79","shell","pm","install","-r","/data/local/tmp/ccc4d5202221a2854897d2f45cf8928f.apk"]
[debug] [MJSONWP] Responding to client with driver.installApp() result: null
[HTTP] <-- POST /wd/hub/session/21dd4871-34bc-4df2-9a47-bf4cd867543f/appium/device/install_app 200 6008 ms - 76
[HTTP] --> POST /wd/hub/session/21dd4871-34bc-4df2-9a47-bf4cd867543f/appium/device/app_installed {"bundleId":"io.appium.android.apis"}
[debug] [MJSONWP] Calling AppiumDriver.isAppInstalled() with args: ["io.appium.android.apis","21dd4871-34bc-4df2-9a47-bf4cd867543f"]
[debug] [ADB] Getting install status for io.appium.android.apis
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[debug] [ADB] Running '/Users/kazucocoa/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","CB5A22LZ79","shell","pm","list","packages","io.appium.android.apis"]
[debug] [ADB] App is installed
[debug] [MJSONWP] Responding to client with driver.isAppInstalled() result: true
[HTTP] <-- POST /wd/hub/session/21dd4871-34bc-4df2-9a47-bf4cd867543f/appium/device/app_installed 200 999 ms - 76
[BaseDriver] Shutting down because we waited 60 seconds for a command
[debug] [UiAutomator2] Deleting UiAutomator2 session
[Appium] Closing session, cause was 'New Command Timeout of 60 seconds expired. Try customizing the timeout using the 'newCommandTimeout' desired capability'
```