### PR TITLE
Throw an exception if running on an unsupported OS

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -248,6 +248,11 @@ class AndroidUiautomator2Driver extends BaseDriver {
     this.adb = await androidHelpers.createADB(this.opts.javaVersion,
       this.opts.udid, this.opts.emPort, this.opts.adbPort);
 
+    if (await this.adb.getApiLevel() < 21) {
+      logger.errorAndThrow('UIAutomation2 is only supported since Android 5.0 (Lollipop). ' +
+        'You could still use other supported backends in order to automate older Android versions.');
+    }
+
     // get appPackage et al from manifest if necessary
     let appInfo = await helpers.getLaunchInfo(this.adb, this.opts);
     // and get it onto our 'opts' object so we use it from now on

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "adbkit": "^2.4.1",
-    "appium-adb": "^4.0.0",
+    "appium-adb": "^4.1.0",
     "appium-android-driver": "^1.27.1",
     "appium-base-driver": "^2.0.18",
     "appium-support": "^2.5.0",

--- a/test/functional/commands/keyboard/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard/keyboard-e2e-specs.js
@@ -169,7 +169,7 @@ describe('keyboard', function () {
 
       it('should be able to type in length-limited field', async function () {
         let adb = new ADB();
-        if (parseInt(await adb.getApiLevel(), 10) < 24) {
+        if (await adb.getApiLevel() < 24) {
           // below Android 7.0 (API level 24) typing too many characters in a
           // length-limited field will either throw a NullPointerException or
           // crash the app


### PR DESCRIPTION
I saw several issue reports about UIA2 is not working properly and then it turns out that people are trying to run it on Android 4.4 or even older versions. This PR should improve the situation.