### PR TITLE
Add systemPort to the list of desired caps

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -26,6 +26,9 @@ let uiautomatorCapConstraints = {
   disableWindowAnimation: {
     isBoolean: true
   },
+  systemPort: {
+    isNumber: true
+  },
 };
 
 let desiredCapConstraints = {};


### PR DESCRIPTION
This is needed to prevent "unknown capability" error from base driver.