### PR TITLE
add execute script to no proxy

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -94,6 +94,12 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/ime/activated')],
   ['POST', new RegExp('^/session/[^/]+/ime/deactivate')],
   ['POST', new RegExp('^/session/[^/]+/ime/activate')],
+  // MJSONWP commands
+  ['POST', new RegExp('^/session/[^/]+/execute')],
+  ['POST', new RegExp('^/session/[^/]+/execute_async')],
+  // W3C commands
+  ['POST', new RegExp('^/session/[^/]+/execute/sync')],
+  ['POST', new RegExp('^/session/[^/]+/execute/async')],
 ];
 
 // This is a set of methods and paths that we never want to proxy to Chromedriver.

--- a/test/functional/commands/mobile-command-e2e-specs.js
+++ b/test/functional/commands/mobile-command-e2e-specs.js
@@ -1,0 +1,24 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { APIDEMOS_CAPS } from '../desired';
+import { initDriver } from '../helpers/session';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('mobile: shell', function () {
+  let driver;
+  before(async () => {
+    driver = await initDriver(APIDEMOS_CAPS);
+  });
+  after(async () => {
+    await driver.quit();
+  });
+  it('should call execute command without proxy error, but require relaxed security flag', async () => {
+    try {
+      await driver.execute('mobile: shell', {command: 'echo', args: ['hello']});
+    } catch (e) {
+      e.message.should.match(/Original error: Appium server must have relaxed security flag set in order to run any shell commands/);
+    }
+  });
+});


### PR DESCRIPTION
When I tied to run `mobile: shell` against uiautomator2 with Ruby client, the following error raised.
After adding them to `NO_PROXY`, the mobile command works well.

```
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while pr
ocessing the command. Original error: Could not proxy. Proxy error: Could not proxy comm
and to remote server. Original error: 404 - undefined
```

Also, I've added the execute command for W3C since I haven't seen this kind of commit.

link: https://github.com/appium/appium-android-driver/pull/293

---

- [x] add functional tests in https://github.com/appium/appium-uiautomator2-driver/tree/master/test/functional/commands
    - I'll add one `mobile: shell` command test

```
dbug ADB Running '/Users/kazuaki/Library/Android/sdk/platform-tools/adb' with args: ["-P",5037,"-s","emulator-5554","forward","--remove","tcp:8200"]
dbug BaseDriver Event 'quitSessionFinished' logged at 1513556257492 (09:17:37 GMT+0900 (JST))
dbug MJSONWP Received response: null
dbug MJSONWP But deleting session, so not returning
dbug MJSONWP Responding to client with driver.deleteSession() result: null
info HTTP <-- DELETE /wd/hub/session/b05b359a-f4c0-4fb3-978d-6f4ada7de75a 200 845 ms - 76 


  1 passing (16s)

rrcs-172-254-99-34:appium-uiautomator2-driver kazuaki$ git status
On branch add_execuite_script_for_no_proxy
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        new file:   test/functional/commands/mobile-command-specs.js
```