### PR TITLE
getProxyAvoidList should not overwrite additional rule

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -134,7 +134,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
     this.jwpProxyActive = false;
     this.defaultIME = null;
     this.jwpProxyAvoid = NO_PROXY;
-    this.additionalJwpProxyAvoid = [];
     this.apkStrings = {}; // map of language -> strings obj
 
     this.settings = new DeviceSettings({ignoreUnimportantViews: false, allowInvisibleElements: false},
@@ -178,10 +177,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
         this.opts.appPackage = this.caps.appPackage = pkg;
         this.opts.appActivity = this.caps.appActivity = activity;
         logger.info(`Chrome-type package and activity are ${pkg} and ${activity}`);
-      }
-
-      if (this.opts.nativeWebScreenshot) {
-        this.additionalJwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);
       }
 
       if (this.opts.reboot) {
@@ -561,7 +556,9 @@ class AndroidUiautomator2Driver extends BaseDriver {
     } else {
       this.jwpProxyAvoid = NO_PROXY;
     }
-    this.jwpProxyAvoid = this.jwpProxyAvoid.concat(this.additionalJwpProxyAvoid);
+    if (this.opts.nativeWebScreenshot) {
+      this.jwpProxyAvoid = [...this.jwpProxyAvoid, ['GET', new RegExp('^/session/[^/]+/screenshot')]];
+    }
 
     return this.jwpProxyAvoid;
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -134,6 +134,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
     this.jwpProxyActive = false;
     this.defaultIME = null;
     this.jwpProxyAvoid = NO_PROXY;
+    this.additionalJwpProxyAvoid = [];
     this.apkStrings = {}; // map of language -> strings obj
 
     this.settings = new DeviceSettings({ignoreUnimportantViews: false, allowInvisibleElements: false},
@@ -180,7 +181,8 @@ class AndroidUiautomator2Driver extends BaseDriver {
       }
 
       if (this.opts.nativeWebScreenshot) {
-        this.jwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);
+        logger.info('nativeWebScreenshot is requested');
+        this.additionalJwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);
       }
 
       if (this.opts.reboot) {
@@ -551,6 +553,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
   }
 
   getProxyAvoidList (sessionId) {
+    logger.info('getProxyAvoidList before super jwpProxyAvoid', this.jwpProxyAvoid);
     super.getProxyAvoidList(sessionId);
     // we are maintaining two sets of NO_PROXY lists, one for chromedriver(CHROME_NO_PROXY)
     // and one for uiautomator2(NO_PROXY), based on current context will return related NO_PROXY list
@@ -560,6 +563,8 @@ class AndroidUiautomator2Driver extends BaseDriver {
     } else {
       this.jwpProxyAvoid = NO_PROXY;
     }
+    this.jwpProxyAvoid = this.jwpProxyAvoid.concat(this.additionalJwpProxyAvoid);
+
     return this.jwpProxyAvoid;
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -181,7 +181,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
       }
 
       if (this.opts.nativeWebScreenshot) {
-        logger.info('nativeWebScreenshot is requested');
         this.additionalJwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);
       }
 
@@ -553,7 +552,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
   }
 
   getProxyAvoidList (sessionId) {
-    logger.info('getProxyAvoidList before super jwpProxyAvoid', this.jwpProxyAvoid);
     super.getProxyAvoidList(sessionId);
     // we are maintaining two sets of NO_PROXY lists, one for chromedriver(CHROME_NO_PROXY)
     // and one for uiautomator2(NO_PROXY), based on current context will return related NO_PROXY list

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -148,9 +148,6 @@ describe('driver.js', () => {
         });
 
         describe('on native mode', function () {
-          beforeEach(function () {
-            driver.chromedriver = null;
-          });
           it('should never proxy screenshot regardless of nativeWebScreenshot setting (on)', async function () {
             // nativeWebScreenshot on
             await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: true});

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -119,8 +119,8 @@ describe('driver.js', () => {
         }).should.throw;
       });
       describe('nativeWebScreenshot', function () {
-        let list;
-        let nativeWebScreenshotFilter = item => { return item[0] === "GET" && item[1].test('/session/xxx/screenshot/');};
+        let proxyAvoidList;
+        let nativeWebScreenshotFilter = item => item[0] === "GET" && item[1].test('/session/xxx/screenshot/');
         beforeEach(function () {
           driver = new AndroidUiautomator2Driver({}, false);
           sinon.mock(driver).expects('checkAppPresent')
@@ -137,13 +137,13 @@ describe('driver.js', () => {
           });
           it('should proxy screenshot if nativeWebScreenshot is off on chromedriver mode', async function () {
             await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: false});
-            list = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
-            list.should.be.empty;
+            proxyAvoidList = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
+            proxyAvoidList.should.be.empty;
           });
           it('should not proxy screenshot if nativeWebScreenshot is on on chromedriver mode', async function () {
             await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: true});
-            list = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
-            list.should.not.be.empty;
+            proxyAvoidList = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
+            proxyAvoidList.should.not.be.empty;
           });
         });
 
@@ -154,15 +154,15 @@ describe('driver.js', () => {
           it('should never proxy screenshot regardless of nativeWebScreenshot setting (on)', async function () {
             // nativeWebScreenshot on
             await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: true});
-            list = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
-            list.should.not.empty;
+            proxyAvoidList = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
+            proxyAvoidList.should.not.be.empty;
           });
 
           it('should never proxy screenshot regardless of nativeWebScreenshot setting (off)', async function () {
             // nativeWebScreenshot off
             await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: false});
-            list = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
-            list.should.not.empty;
+            proxyAvoidList = driver.getProxyAvoidList().filter(nativeWebScreenshotFilter);
+            proxyAvoidList.should.not.be.empty;
           });
         });
       });


### PR DESCRIPTION
**Issue:**
nativeWebScreenshot preference was overwritten on each getProxyAvoidList call. This makes screenshot command getting proxied to chromedriver when user is on webview mode. Which most likely will timeout.

**Implementation:**
Fix test cases to actually check proxyAvoidList content by feeding in `/session/zzz/screenshoot/`.
Former test for nativeWebScreenshot had false positive since NO_PROXY list is already over 40 items.
Add additional test cases to specify native mode behavior which ignores nativeWebScreenshot setting.  