### PR TITLE
fix JWProxy opt key. Also pass adb host to adbkit

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -349,7 +349,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
     // now that we have package and activity, we can create an instance of
     // uiautomator2 with the appropriate data
     this.uiautomator2 = new UiAutomator2Server({
-      host: this.opts.host || 'localhost',
+      host: this.opts.remoteAdbHost || this.opts.host || 'localhost',
       systemPort: this.opts.systemPort,
       devicePort: DEVICE_PORT,
       adb: this.adb,

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -20,11 +20,12 @@ class UiAutomator2Server {
       }
       this[req] = opts[req];
     }
-    this.jwproxy = new JWProxy({host: this.host, port: this.systemPort});
+    this.jwproxy = new JWProxy({server: this.host, port: this.systemPort});
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
 
     this.client = adbkit.createClient({
       port: this.adb.adbPort,
+      host: this.host
     });
   }
 


### PR DESCRIPTION
This change is needed if we are running tests on a device connected to the remote machine. 
1)JWProxy uses  :server instead of :host
2) tell adbkit about remoteAdbHost instead of assuming localhost. This fixes starting instrumentation on remote machine with 'adb shell am instrument..' 