### PR TITLE
Window rect for w3c

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -51,12 +51,13 @@ commands.getWindowSize = async function () {
 
 // For W3C
 commands.getWindowRect = async function () {
-  const rect = await this.getWindowSize();
-  if (_.isObject(rect)) {
-    rect.x = 0;
-    rect.y = 0;
-  }
-  return rect;
+  const {width, height} = await this.getWindowSize();
+  return {
+    width,
+    height,
+    x: 0,
+    y: 0,
+  };
 };
 
 extensions.executeMobile = async function (mobileCommand, opts = {}) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -49,6 +49,16 @@ commands.getWindowSize = async function () {
   return await this.uiautomator2.jwproxy.command('/window/current/size', 'GET', {});
 };
 
+// For W3C
+commands.getWindowRect = async function () {
+  const rect = await this.getWindowSize();
+  if (_.isObject(rect)) {
+    rect.x = 0;
+    rect.y = 0;
+  }
+  return rect;
+};
+
 extensions.executeMobile = async function (mobileCommand, opts = {}) {
   const mobileCommandsMapping = {
     shell: async (x) => await this.mobileShell(x),

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -101,6 +101,7 @@ const NO_PROXY = [
   // W3C commands
   ['POST', new RegExp('^/session/[^/]+/execute/sync')],
   ['POST', new RegExp('^/session/[^/]+/execute/async')],
+  ['GET', new RegExp('^/session/[^/]+/window/rect')],
 ];
 
 // This is a set of methods and paths that we never want to proxy to Chromedriver.

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -1,0 +1,30 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import AndroidUiautomator2Driver from '../../..';
+
+let driver;
+let sandbox = sinon.sandbox.create();
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('General', () => {
+  describe('getWindowRect', () => {
+    beforeEach(async () => {
+      driver = new AndroidUiautomator2Driver();
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should get window size', async () => {
+      sandbox.stub(driver, 'getWindowSize')
+          .withArgs().returns({width: 300, height: 400});
+      const result = await driver.getWindowRect();
+      result.width.should.be.equal(300);
+      result.height.should.be.equal(400);
+      result.x.should.be.equal(0);
+      result.y.should.be.equal(0);
+    });
+  });
+});

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -8,16 +8,16 @@ let sandbox = sinon.sandbox.create();
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('General', () => {
-  describe('getWindowRect', () => {
-    beforeEach(async () => {
+describe('General', function () {
+  describe('getWindowRect', function () {
+    beforeEach(async function () {
       driver = new AndroidUiautomator2Driver();
     });
-    afterEach(() => {
+    afterEach(function () {
       sandbox.restore();
     });
 
-    it('should get window size', async () => {
+    it('should get window size', async function () {
       sandbox.stub(driver, 'getWindowSize')
           .withArgs().returns({width: 300, height: 400});
       const result = await driver.getWindowRect();


### PR DESCRIPTION
https://github.com/appium/appium-xcuitest-driver/pull/607 for uiautomator2.


## After

```
[debug] [MJSONWP] Responding to client with driver.getWindowRect() result: {"height":1794,"width":1080,"x":0,"y":0}
[HTTP] <-- GET /wd/hub/session/c8a361e8-9d63-4535-aba7-6d4931ceada7/window/rect 200 37 ms - 50
[HTTP] --> GET /wd/hub/session/c8a361e8-9d63-4535-aba7-6d4931ceada7/window/rect {}
[debug] [MJSONWP] Calling AppiumDriver.getWindowRect() with args: ["c8a361e8-9d63-4535-aba7-6d4931ceada7"]
[debug] [JSONWP Proxy] Proxying [GET /window/current/size] to [GET http://localhost:8208/wd/hub/session/836468f0-151b-44ae-950c-f7b9ade9ae08/window/current/size] with body: {}
[debug] [JSONWP Proxy] Got response with status 200: "{\"sessionId\":\"836468f0-151b-44ae-950c-f7b9ade9ae08\",\"status\":0,\"value\":{\"height\":1794,\"width\":1080}}"
[debug] [MJSONWP] Responding to client with driver.getWindowRect() result: {"height":1794,"width":1080,"x":0,"y":0}
[HTTP] <-- GET /wd/hub/session/c8a361e8-9d63-4535-aba7-6d4931ceada7/window/rect 200 22 ms - 50
[BaseDriver] Shutting down because we waited 60 seconds for a command
```