### PR TITLE
Unlock the device after the session has been started

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -289,12 +289,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
     logger.debug(`Forwarding UiAutomator2 Server port ${DEVICE_PORT} to ${this.opts.systemPort}`);
     await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
 
-    if (!this.opts.skipUnlock) {
-      // unlock the device to prepare it for testing
-      await helpers.unlock(this, this.adb, this.caps);
-    } else {
-      logger.debug(`'skipUnlock' capability set, so skipping device unlock`);
-    }
     // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
     if (this.opts.autoLaunch) {
       // set up app under test
@@ -308,6 +302,14 @@ class AndroidUiautomator2Driver extends BaseDriver {
 
     // launch UiAutomator2 and wait till its online and we have a session
     await this.uiautomator2.startSession(this.caps);
+
+	// Unlock the device after the session is started.
+    if (!this.opts.skipUnlock) {
+      // unlock the device to prepare it for testing
+      await helpers.unlock(this, this.adb, this.caps);
+    } else {
+      logger.debug(`'skipUnlock' capability set, so skipping device unlock`);
+    }
 
     // rescue UiAutomator2 if it fails to start our AUT
     if (this.opts.autoLaunch) {

--- a/test/unit/commands/touch-specs.js
+++ b/test/unit/commands/touch-specs.js
@@ -14,7 +14,7 @@ describe('Touch', function () {
 
   describe('#parseTouch', function () {
     describe('given a touch sequence with absolute coordinates', function () {
-      it('should use offsets for moveTo', async function () {
+      it('should use absolutes for moveTo', async function () {
         // let driver = new AndroidDriver({foo: 'bar'});
         let actions = [
           {action: 'press', options: {x: 100, y: 101}},
@@ -27,9 +27,9 @@ describe('Touch', function () {
         touchStates.length.should.equal(5);
         let parsedActions = [
           {action: 'press', x: 100, y: 101},
-          {action: 'moveTo', x: 150, y: 152},
-          {action: 'wait', x: 150, y: 152},
-          {action: 'moveTo', x: 110, y: 111},
+          {action: 'moveTo', x: 50, y: 51},
+          {action: 'wait', x: 50, y: 51},
+          {action: 'moveTo', x: -40, y: -41},
           {action: 'release'}
         ];
         let index = 0;


### PR DESCRIPTION
Unlocking the device depends on an API which requires a session ID.
startUiAutomator2Session needs to start the session before trying to unlock the device.