### PR TITLE
appium-adb introducing new install function signature

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -107,7 +107,7 @@ class UiAutomator2Server {
 
   async signAndInstall (apk, apkPackage, timeout = SERVER_INSTALL_RETRIES * 1000, test = false) {
     await this.checkAndSignCert(apk, apkPackage);
-    await this.adb.install(apk, true, timeout);
+    await this.adb.install(apk, {replace: true, timeout});
     logger.info(`Installed UiAutomator2 server${test ? ' test' : ''} apk`);
   }
 


### PR DESCRIPTION
Issue:
apk installation failed on latest appium beta.
```
[MJSONWP] Encountered internal error running command: TypeError: Cannot create property 'replace' on boolean 'true'
    at ADB.callee$0$0$ (/mypath/node_modules/appium-adb/lib/tools/apk-utils.js:331:20)
```

Cause:
https://github.com/appium/appium-adb/blob/d366120e6e30dc4bf1d68306d70888a4db758a1d/lib/tools/apk-utils.js#L329

new signature: `install(apk, options = {})`
previous signature: `install(apk, replace = true, timeout = 6000)`

Fixes:
Update install command.

Note:
I'm not sure how to write test for this.
Introducing `installWithOptions` while deprecating `install` probably a good choice (on appium-adb)