### PR TITLE
fix proxy error for activate and terminate app

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -81,6 +81,8 @@ const NO_PROXY = [
   ['GET', new RegExp('^/session/[^/]+/log/types')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/remove_app')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/install_app')],
+  ['POST', new RegExp('^/session/[^/]+/appium/device/terminate_app')],
+  ['POST', new RegExp('^/session/[^/]+/appium/device/activate_app')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/current_package')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/display_density')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/system_bars')],

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -83,6 +83,7 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/appium/device/install_app')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/terminate_app')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/activate_app')],
+  ['GET', new RegExp('^/session/[^/]+/appium/device/app_state')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/current_package')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/display_density')],
   ['GET', new RegExp('^/session/[^/]+/appium/device/system_bars')],


### PR DESCRIPTION
Fix the following proxy error for `terminate_app` and `activate_app`

```
[HTTP] --> POST /wd/hub/session/c579c9fc-32cc-49b8-9dc5-3ad46c4fe80f/appium/device/terminate_app {"appId":"io.appium.android.apis"}
[W3C] Driver proxy active, passing request on via HTTP proxy
[debug] [JSONWP Proxy] Proxying [POST /wd/hub/session/c579c9fc-32cc-49b8-9dc5-3ad46c4fe80f/appium/device/terminate_app] to [POST http://localhost:8200/wd/hub/session/328f5c81-65c3-41dd-9c8b-ad819dbf29fc/appium/device/terminate_app] with body: {"appId":"io.appium.android.apis"}
[W3C] Encountered internal error running command: Error: Could not proxy. Proxy error: Could not proxy command to remote server. Original error: 404 - undefined
    at doJwpProxy$ (/Users/kazuaki/GitHub/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:404:13)
    at tryCatch (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at <anonymous>
[HTTP] <-- POST /wd/hub/session/c579c9fc-32cc-49b8-9dc5-3ad46c4fe80f/appium/device/terminate_app 500 49 ms - 1315
[HTTP] --> POST /wd/hub/session/c579c9fc-32cc-49b8-9dc5-3ad46c4fe80f/appium/device/activate_app {"bundleId":"io.appium.android.apis"}
[W3C] Driver proxy active, passing request on via HTTP proxy
[debug] [JSONWP Proxy] Proxying [POST /wd/hub/session/c579c9fc-32cc-49b8-9dc5-3ad46c4fe80f/appium/device/activate_app] to [POST http://localhost:8200/wd/hub/session/328f5c81-65c3-41dd-9c8b-ad819dbf29fc/appium/device/activate_app] with body: {"bundleId":"io.appium.android.apis"}
[W3C] Encountered internal error running command: Error: Could not proxy. Proxy error: Could not proxy command to remote server. Original error: 404 - undefined
    at doJwpProxy$ (/Users/kazuaki/GitHub/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:404:13)
    at tryCatch (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as throw] (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/kazuaki/GitHub/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at <anonymous>
[HTTP] <-- POST /wd/hub/session/c579c9fc-32cc-49b8-9dc5-3ad46c4fe80f/appium/device/activate_app 500 15 ms - 1315
[HTTP] --> POST /wd/hub/session/c579c9fc-32cc-49b8-9dc5-3ad46c4fe80f/appium/device/app_installed {"bundleId":"io.appium.android.apis"}
[debug] [W3
```

https://github.com/appium/ruby_lib_core/pull/58