### PR TITLE
Add retry to startApp method call

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -397,7 +397,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
         waitActivity: this.opts.appWaitActivity,
         optionalIntentArguments: this.opts.optionalIntentArguments,
         stopApp: !this.opts.dontStopAppOnReset,
-        retry: false
+        retry: true
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "adbkit": "^2.4.1",
     "appium-adb": "^6.0.1",
-    "appium-android-driver": "^2.0.0",
+    "appium-android-driver": "^2.1.3",
     "appium-base-driver": "^2.18.4",
     "appium-support": "^2.12.0",
     "appium-uiautomator2-server": "1.x",


### PR DESCRIPTION
* Now that we use `apkAnalyzer` to parse activity names, it's not always going to be the case that an activity name will be "fully qualified"
* We need to set retry to `true` again so that if the activity does not have '.' in front of it, try again with the dot
  * e.g.: If running activity `io.appium.android.apis/ApiDemos` does not work, make it try again with `io.appium.android.apis/.ApiDemos`

(related to https://github.com/appium/appium-adb/pull/308)

(connected to issue https://github.com/appium/appium/issues/10381)