### PR TITLE
allow isEmulator to be true when udid is set to an emulator

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -203,7 +203,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
   }
 
   isEmulator () {
-    return !!this.opts.avd;
+    return !!(this.opts.avd || /emulator/.test(this.opts.udid));
   }
 
   setAvdFromCapabilities (caps) {


### PR DESCRIPTION
essentially copying what AndroidDriver does