### PR TITLE
createSession should return session's capabilities

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -178,7 +178,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
 
       await this.startUiAutomator2Session();
       await this.fillDeviceDetails();
-      return [sessionId, caps];
+      return [sessionId, this.caps];
     } catch (e) {
       await this.deleteSession();
       throw e;


### PR DESCRIPTION
`createSession` return the desired capabilities.
According to JSON Wire Protocol that `createSession` should return the actual session's capabilities.

https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#post-session
