### PR TITLE
Fix get/post settings

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -102,14 +102,6 @@ commands.openNotifications = async function () {
   return await this.uiautomator2.jwproxy.command('/appium/device/open_notifications', 'POST', {});
 };
 
-commands.updateSettings = async function (settings) {
-  return await this.uiautomator2.jwproxy.command('/appium/settings', 'POST', {settings});
-};
-
-commands.getSettings = async function () {
-  return await this.uiautomator2.jwproxy.command('/appium/settings', 'GET');
-};
-
 /**
  * Overriding appium-android-driver's wrapBootstrapDisconnect,
  * unlike in appium-android-driver avoiding adb restarting as it intern


### PR DESCRIPTION
When I run ruby_lib_core test suite, I found broken setting commands for UA2. It can see with Appium 1.8.0. (It works with 1.7.2)

### After

```ruby
[1] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.get_settings
=> {"ignoreUnimportantViews"=>false, "allowInvisibleElements"=>false}
[2] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.update_settings('ignoreUnimportantViews' => true)
=> nil
[3] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.get_settings
=> {"ignoreUnimportantViews"=>true, "allowInvisibleElements"=>false}
```




```
[HTTP] --> GET /wd/hub/session/53a21f63-df5b-4462-b28a-c830108f023f/appium/settings
[HTTP] {}
[debug] [W3C] Calling AppiumDriver.getSettings() with args: ["53a21f63-df5b-4462-b28a-c830108f023f"]
[debug] [W3C] Responding to client with driver.getSettings() result: {"ignoreUnimportantViews":false,"allowInvisibleElements":false}
[HTTP] <-- GET /wd/hub/session/53a21f63-df5b-4462-b28a-c830108f023f/appium/settings 200 6 ms - 73
[HTTP]
[HTTP] --> POST /wd/hub/session/53a21f63-df5b-4462-b28a-c830108f023f/appium/settings
[HTTP] {"settings":{"ignoreUnimportantViews":true}}
[debug] [W3C] Calling AppiumDriver.updateSettings() with args: [{"ignoreUnimportantViews":true},"53a21f63-df5b-4462-b28a-c830108f023f"]
[debug] [JSONWP Proxy] Proxying [POST /appium/settings] to [POST http://localhost:8203/wd/hub/session/0077a1c1-dbdb-4e06-b323-8332bfa7bbc7/appium/settings] with body: {"settings":{"ignoreUnimportantViews":true}}
[debug] [JSONWP Proxy] Got response with status 200: {"sessionId":"0077a1c1-dbdb-4e06-b323-8332bfa7bbc7","status":0,"value":true}
[debug] [W3C] Responding to client with driver.updateSettings() result: null
[HTTP] <-- POST /wd/hub/session/53a21f63-df5b-4462-b28a-c830108f023f/appium/settings 200 19 ms - 14
[HTTP]
[HTTP] --> GET /wd/hub/session/53a21f63-df5b-4462-b28a-c830108f023f/appium/settings
[HTTP] {}
[debug] [W3C] Calling AppiumDriver.getSettings() with args: ["53a21f63-df5b-4462-b28a-c830108f023f"]
[debug] [W3C] Responding to client with driver.getSettings() result: {"ignoreUnimportantViews":true,"allowInvisibleElements":false}
[HTTP] <-- GET /wd/hub/session/53a21f63-df5b-4462-b28a-c830108f023f/appium/settings 200 3 ms - 72
[HTTP]
```

### Before


```ruby
[1] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.get_settings
Selenium::WebDriver::Error::ServerError: status code 400
from /Users/kazuaki/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/selenium-webdriver-3.11.0/lib/selenium/webdriver/remote/response.rb:72:in `assert_ok'
[2] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.update_settings('ignoreUnimportantViews' => true)
=> true
[3] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> 
```


```
[HTTP] --> GET /wd/hub/session/c161cf5b-02cb-4d82-bc39-4498ae7fafca/appium/settings
[HTTP] {}
[debug] [W3C] Calling AppiumDriver.getSettings() with args: ["c161cf5b-02cb-4d82-bc39-4498ae7fafca"]
[debug] [JSONWP Proxy] Proxying [GET /appium/settings] to [GET http://localhost:8203/wd/hub/session/834fe257-3225-40a7-b00a-b0b6ea073555/appium/settings] with no body
[HTTP] <-- GET /wd/hub/session/c161cf5b-02cb-4d82-bc39-4498ae7fafca/appium/settings 400 48 ms - 1076
[HTTP]
[HTTP] --> POST /wd/hub/session/c161cf5b-02cb-4d82-bc39-4498ae7fafca/appium/settings
[HTTP] {"settings":{"ignoreUnimportantViews":true}}
[debug] [W3C] Calling AppiumDriver.updateSettings() with args: [{"ignoreUnimportantViews":true},"c161cf5b-02cb-4d82-bc39-4498ae7fafca"]
[debug] [JSONWP Proxy] Proxying [POST /appium/settings] to [POST http://localhost:8203/wd/hub/session/834fe257-3225-40a7-b00a-b0b6ea073555/appium/settings] with body: {"settings":{"ignoreUnimportantViews":true}}
[debug] [JSONWP Proxy] Got response with status 200: {"sessionId":"834fe257-3225-40a7-b00a-b0b6ea073555","status":0,"value":true}
[debug] [W3C] Responding to client with driver.updateSettings() result: true
[HTTP] <-- POST /wd/hub/session/c161cf5b-02cb-4d82-bc39-4498ae7fafca/appium/settings 200 49 ms - 14
[HTTP]
```

### Before (Only remove GET)

In this case, the `ignoreUnimportantViews` value doesn't change.

```ruby
[1] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.get_settings
=> {"ignoreUnimportantViews"=>false, "allowInvisibleElements"=>false}
[2] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.update_settings('ignoreUnimportantViews' => true)
=> true
[3] pry(#<AppiumLibCoreTest::Android::DeviceTest>)> @@driver.get_settings
=> {"ignoreUnimportantViews"=>false, "allowInvisibleElements"=>false}
```

```
[HTTP] --> GET /wd/hub/session/7d27bb0a-1a20-4525-9c65-0257075b9956/appium/settings
[HTTP] {}
[debug] [W3C] Calling AppiumDriver.getSettings() with args: ["7d27bb0a-1a20-4525-9c65-0257075b9956"]
[debug] [W3C] Responding to client with driver.getSettings() result: {"ignoreUnimportantViews":false,"allowInvisibleElements":false}
[HTTP] <-- GET /wd/hub/session/7d27bb0a-1a20-4525-9c65-0257075b9956/appium/settings 200 6 ms - 73
[HTTP]
[HTTP] --> POST /wd/hub/session/7d27bb0a-1a20-4525-9c65-0257075b9956/appium/settings
[HTTP] {"settings":{"ignoreUnimportantViews":true}}
[debug] [W3C] Calling AppiumDriver.updateSettings() with args: [{"ignoreUnimportantViews":true},"7d27bb0a-1a20-4525-9c65-0257075b9956"]
[debug] [JSONWP Proxy] Proxying [POST /appium/settings] to [POST http://localhost:8203/wd/hub/session/3268a0cf-46d5-41ef-9dfa-32a3760a4686/appium/settings] with body: {"settings":{"ignoreUnimportantViews":true}}
[debug] [JSONWP Proxy] Got response with status 200: {"sessionId":"3268a0cf-46d5-41ef-9dfa-32a3760a4686","status":0,"value":true}
[debug] [W3C] Responding to client with driver.updateSettings() result: true
[HTTP] <-- POST /wd/hub/session/7d27bb0a-1a20-4525-9c65-0257075b9956/appium/settings 200 45 ms - 14
[HTTP]
[HTTP] --> GET /wd/hub/session/7d27bb0a-1a20-4525-9c65-0257075b9956/appium/settings
[HTTP] {}
[debug] [W3C] Calling AppiumDriver.getSettings() with args: ["7d27bb0a-1a20-4525-9c65-0257075b9956"]
[debug] [W3C] Responding to client with driver.getSettings() result: {"ignoreUnimportantViews":false,"allowInvisibleElements":false}
[HTTP] <-- GET /wd/hub/session/7d27bb0a-1a20-4525-9c65-0257075b9956/appium/settings 200 6 ms - 73
[HTTP]
```