### PR TITLE
Add compare_images to the list of NO_PROXY endpoints

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -51,6 +51,7 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/app/[^/]')],
   ['POST', new RegExp('^/session/[^/]+/appium/[^/]+/start_activity')],
   ['POST', new RegExp('^/session/[^/]+/appium/app/[^/]+')],
+  ['POST', new RegExp('^/session/[^/]+/appium/compare_images')],
   ['POST', new RegExp('^/session/[^/]+/appium/device/(?!set_clipboard|get_clipboard)[^/]+')],
   ['POST', new RegExp('^/session/[^/]+/appium/element/[^/]+/replace_value')],
   ['POST', new RegExp('^/session/[^/]+/appium/element/[^/]+/value')],


### PR DESCRIPTION
The call to this endpoint simply freezes otherwise