### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-uiautomator2
-*.log
-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
 install:
   # node stuff
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-  - nvm install 6
+  - nvm install 8
   - node --version
   - npm --version
   - npm install appium-test-support # get the travis emu scripts

--- a/lib/commands/alert.js
+++ b/lib/commands/alert.js
@@ -12,12 +12,12 @@ commands.getAlertText = async function () {
  *                                   automatically.
  */
 
- /**
-  * @param {AcceptAlertOptions} opts
-  * @throws {InvalidElementStateError} If no matching button, that can accept the alert,
-  *                                    can be found
-  * @throws {NoAlertOpenError} If no alert is present
-  */
+/**
+ * @param {AcceptAlertOptions} opts
+ * @throws {InvalidElementStateError} If no matching button, that can accept the alert,
+ *                                    can be found
+ * @throws {NoAlertOpenError} If no alert is present
+ */
 commands.mobileAcceptAlert = async function (opts = {}) {
   return await this.uiautomator2.jwproxy.command('/alert/accept', 'POST', opts);
 };
@@ -34,12 +34,12 @@ commands.postAcceptAlert = async function () {
  *                                   automatically.
  */
 
- /**
-  * @param {DismissAlertOptions} opts
-  * @throws {InvalidElementStateError} If no matching button, that can dismiss the alert,
-  *                                    can be found
-  * @throws {NoAlertOpenError} If no alert is present
-  */
+/**
+ * @param {DismissAlertOptions} opts
+ * @throws {InvalidElementStateError} If no matching button, that can dismiss the alert,
+ *                                    can be found
+ * @throws {NoAlertOpenError} If no alert is present
+ */
 commands.mobileDismissAlert = async function (opts = {}) {
   return await this.uiautomator2.jwproxy.command('/alert/dismiss', 'POST', opts);
 };

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -7,7 +7,7 @@ let extensions = {},
     commands = {},
     helpers = {};
 
-commands.getPageSource = async function  () {
+commands.getPageSource = async function () {
   return await this.uiautomator2.jwproxy.command('/source', 'GET', {});
 };
 
@@ -104,7 +104,7 @@ commands.setUrl = async function (url) {
 };
 
 commands.mobileDeepLink = async function (opts = {}) {
-  const {url, package:pkg} = opts;
+  const {url, package: pkg} = opts;
   return await this.adb.startUri(url, pkg);
 };
 
@@ -153,7 +153,7 @@ commands.getSettings = async function () {
  * unlike in appium-android-driver avoiding adb restarting as it intern
  * kills UiAutomator2 server running in the device.
  **/
-helpers.wrapBootstrapDisconnect = async function (wrapped)  {
+helpers.wrapBootstrapDisconnect = async function (wrapped) {
   await wrapped();
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -7,7 +7,7 @@ import B from 'bluebird';
 import logger from './logger';
 import commands from './commands/index';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
-import * as uiautomator2Helpers from './helpers';
+import uiautomator2Helpers from './helpers';
 import { androidHelpers, androidCommands } from 'appium-android-driver';
 import desiredCapConstraints from './desired-caps';
 import { findAPortNotInUse } from 'portscanner';
@@ -28,7 +28,7 @@ const DEVICE_PORT = 6790;
 // TODO: Need to segregate the paths better way using regular expressions wherever applicable.
 // (Not segregating right away because more paths to be added in the NO_PROXY list)
 const NO_PROXY = [
-  ['GET', new RegExp('^/session/(?!.*\/)')],
+  ['GET', new RegExp('^/session/(?!.*/)')],
   ['GET', new RegExp('^/session/[^/]+/alert_[^/]+')],
   ['GET', new RegExp('^/session/[^/]+/alert/[^/]+')],
   ['GET', new RegExp('^/session/[^/]+/appium/[^/]+/current_activity')],
@@ -147,7 +147,8 @@ class AndroidUiautomator2Driver extends BaseDriver {
       // TODO handle otherSessionData for multiple sessions
       let [sessionId, caps] = await super.createSession(...args);
 
-      let serverDetails = {platform: 'LINUX',
+      let serverDetails = {
+        platform: 'LINUX',
         webStorageEnabled: false,
         takesScreenshot: true,
         javascriptEnabled: true,
@@ -155,7 +156,8 @@ class AndroidUiautomator2Driver extends BaseDriver {
         networkConnectionEnabled: true,
         locationContextEnabled: false,
         warnings: {},
-        desired: this.caps};
+        desired: this.caps,
+      };
 
       this.caps = Object.assign(serverDetails, this.caps);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,7 +3,7 @@ import { server as baseServer, routeConfiguringFunction } from 'appium-base-driv
 import AndroidUiautomator2Driver from './driver';
 
 
-async function startServer (port=4884, host='localhost') {
+async function startServer (port = 4884, host = 'localhost') {
   let d = new AndroidUiautomator2Driver({port, host});
   let router = routeConfiguringFunction(d);
   let server = baseServer(router, port, host);

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -123,7 +123,7 @@ class UiAutomator2Server {
     await this.jwproxy.command('/session', 'POST', {desiredCapabilities: caps});
   }
 
-  async startSessionUsingAdbKit (deviceUDID) {
+  async startSessionUsingAdbKit (deviceUDID) { // eslint-disable-line require-await
     let cmd = 'am instrument -w';
     if (this.disableWindowAnimation) {
       cmd = `${cmd} --no-window-animation`;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,14 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "adbkit": "^2.4.1",
     "appium-adb": "^6.5.2",
     "appium-android-driver": "^4.0.0",
@@ -33,7 +40,6 @@
     "appium-support": "^2.18.0",
     "appium-uiautomator2-server": "^1.19.0",
     "asyncbox": "^2.3.1",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",
     "portscanner": "2.2.0",
@@ -41,12 +47,10 @@
     "request-promise": "^4.1.1",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.3.1",
-    "utf7": "^1.0.0",
-    "ws": "^6.0.0",
     "yargs": "^12.0.1"
   },
   "scripts": {
-    "prepublish": "rimraf build && gulp prepublish",
+    "prepare": "rimraf build && gulp prepublish",
     "transpile": "gulp transpile",
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "build": "gulp transpile",
@@ -69,20 +73,20 @@
     "test"
   ],
   "devDependencies": {
+    "ajv": "^6.5.3",
     "android-apidemos": "^3.0.0",
-    "appium-gulp-plugins": "^2.2.1",
+    "appium-gulp-plugins": "^3.1.0",
     "appium-test-support": "^1.0.0",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
     "gps-demo-app": "^2.1.1",
-    "gulp": "^3.9.0",
+    "gulp": "^4.0.0",
     "pngjs": "^3.3.1",
     "pre-commit": "^1.2.2",
     "rimraf": "^2.6.1",
@@ -93,16 +97,6 @@
     "xpath": "^0.0.27"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/functional/commands/general/general-e2e-specs.js
+++ b/test/functional/commands/general/general-e2e-specs.js
@@ -20,8 +20,8 @@ describe('general', function () {
 
   describe('startActivity', function () {
     it('should launch a new package and activity', async function () {
-      let appPackage =  await driver.getCurrentPackage();
-      let appActivity =  await driver.getCurrentActivity();
+      let appPackage = await driver.getCurrentPackage();
+      let appActivity = await driver.getCurrentActivity();
       appPackage.should.equal('io.appium.android.apis');
       appActivity.should.equal('.ApiDemos');
 
@@ -30,8 +30,8 @@ describe('general', function () {
 
       await driver.startActivity({appPackage: startAppPackage, appActivity: startAppActivity});
 
-      let newAppPackage =  await driver.getCurrentPackage();
-      let newAppActivity =  await driver.getCurrentActivity();
+      let newAppPackage = await driver.getCurrentPackage();
+      let newAppActivity = await driver.getCurrentActivity();
       newAppPackage.should.equal(startAppPackage);
       newAppActivity.should.equal(startAppActivity);
     });
@@ -42,7 +42,7 @@ describe('general', function () {
 
       await driver.startActivity({appPackage: startAppPackage, appActivity: startAppActivity, intentCategory: startIntentCategory});
 
-      let appActivity =  await driver.getCurrentActivity();
+      let appActivity = await driver.getCurrentActivity();
       appActivity.should.include('HelloWorld');
     });
     it('should be able to launch activity with dontStopAppOnReset = true', async function () {
@@ -50,8 +50,8 @@ describe('general', function () {
       let startAppActivity = '.os.MorseCode';
       await driver.startActivity({appPackage: startAppPackage, appActivity: startAppActivity});
 
-      let appPackage =  await driver.getCurrentPackage();
-      let appActivity =  await driver.getCurrentActivity();
+      let appPackage = await driver.getCurrentPackage();
+      let appActivity = await driver.getCurrentActivity();
       appPackage.should.equal(startAppPackage);
       appActivity.should.equal(startAppActivity);
     });

--- a/test/functional/commands/general/source-e2e-specs.js
+++ b/test/functional/commands/general/source-e2e-specs.js
@@ -9,7 +9,7 @@ import { initDriver } from '../../helpers/session';
 chai.should();
 chai.use(chaiAsPromised);
 
-let assertSource = async (source) => {
+let assertSource = (source) => {
   source.should.exist;
   let dom = new DOMParser().parseFromString(source);
   let nodes = xpath.select('//hierarchy', dom);
@@ -26,7 +26,7 @@ describe('apidemo - source', function () {
   });
   it('should return the page source', async function () {
     let source = await driver.source();
-    await assertSource(source);
+    assertSource(source);
   });
   it('should get less source when compression is enabled', async function () {
     let getSourceWithoutCompression = async () => {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -10,7 +10,7 @@ chai.use(chaiAsPromised);
 
 describe('General', function () {
   describe('getWindowRect', function () {
-    beforeEach(async function () {
+    beforeEach(function () {
       driver = new AndroidUiautomator2Driver();
     });
     afterEach(function () {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -56,7 +56,7 @@ describe('driver.js', function () {
     });
   });
 
-  describe('checkAppPresent', async function () {
+  describe('checkAppPresent', function () {
     it('should resolve if app present', async function () {
       let driver = new AndroidUiautomator2Driver({}, false);
       defaultStub(driver);

--- a/test/unit/uiautomator2-helper-specs.js
+++ b/test/unit/uiautomator2-helper-specs.js
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import * as helpers from '../../lib/helpers';
+import helpers from '../../lib/helpers';
 import ADB from 'appium-adb';
 import { withMocks } from 'appium-test-support';
 


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.