### PR TITLE
Fix strings extraction

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -35,7 +35,7 @@ commands.getStrings = async function (language) {
 
   // Clients require the resulting mapping to have both keys
   // and values of type string
-  const preprocessStringsMap = (mapping) => {
+  const preprocessStringsMap = function (mapping) {
     const result = {};
     for (const [key, value] of _.toPairs(mapping)) {
       result[key] = _.isString(value) ? value : JSON.stringify(value);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import log from '../logger';
-import { androidHelpers } from 'appium-android-driver';
 import { errors, BASEDRIVER_HANDLED_SETTINGS } from 'appium-base-driver';
+import { fs, tempDir } from 'appium-support';
 
 let extensions = {},
     commands = {},
@@ -33,16 +33,54 @@ commands.getStrings = async function (language) {
     log.info(`No language specified, returning strings for: ${language}`);
   }
 
+  // Clients require the resulting mapping to have both keys
+  // and values of type string
+  const preprocessStringsMap = (mapping) => {
+    const result = {};
+    for (const [key, value] of _.toPairs(mapping)) {
+      result[key] = _.isString(value) ? value : JSON.stringify(value);
+    }
+    return result;
+  };
+
   if (this.apkStrings[language]) {
     // Return cached strings
-    return this.apkStrings[language];
+    return preprocessStringsMap(this.apkStrings[language]);
   }
 
-  // TODO: This is mutating the current language, but it's how appium currently works
-  this.apkStrings[language] = await androidHelpers.pushStrings(language, this.adb, this.opts);
-  await this.uiautomator2.jwproxy.command(`/appium/app/strings`, 'POST', {});
+  let app = this.opts.app;
+  if (!app && !this.opts.appPackage) {
+    log.info('No app or package specified. Returning empty strings');
+    return {};
+  }
 
-  return this.apkStrings[language];
+  const tmpRoot = await tempDir.openDir();
+  try {
+    if (!app) {
+      try {
+        app = await this.adb.pullApk(this.opts.appPackage, tmpRoot);
+      } catch (err) {
+        log.warn(`Failed to pull an apk from '${this.opts.appPackage}'. Original error: ${err.message}`);
+        return {};
+      }
+    }
+
+    if (!await fs.exists(app)) {
+      log.info(`The app at '${app}' does not exist. Returning empty strings`);
+      return {};
+    }
+
+    try {
+      const {apkStrings} = await this.adb.extractStringsFromApk(app, language, tmpRoot);
+      this.apkStrings[language] = apkStrings;
+      return preprocessStringsMap(apkStrings);
+    } catch (err) {
+      log.warn(`Cannot extract strings from '${app}'. Original error: ${err.message}`);
+      return {};
+    }
+  } finally {
+    await fs.rimraf(tmpRoot);
+  }
 };
 
 // memoized in constructor

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -49,7 +49,7 @@ commands.getStrings = async function (language) {
   }
 
   if (!this.opts.app && !this.opts.appPackage) {
-    log.errorAndThrow('No app or package specified. Cannot extract strings');
+    log.errorAndThrow("One of 'app' or 'appPackage' capabilities should must be specified");
   }
 
   let app = this.opts.app;

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -48,26 +48,23 @@ commands.getStrings = async function (language) {
     return preprocessStringsMap(this.apkStrings[language]);
   }
 
-  let app = this.opts.app;
-  if (!app && !this.opts.appPackage) {
-    log.info('No app or package specified. Returning empty strings');
-    return {};
+  if (!this.opts.app && !this.opts.appPackage) {
+    log.errorAndThrow('No app or package specified. Cannot extract strings');
   }
 
+  let app = this.opts.app;
   const tmpRoot = await tempDir.openDir();
   try {
     if (!app) {
       try {
         app = await this.adb.pullApk(this.opts.appPackage, tmpRoot);
       } catch (err) {
-        log.warn(`Failed to pull an apk from '${this.opts.appPackage}'. Original error: ${err.message}`);
-        return {};
+        log.errorAndThrow(`Failed to pull an apk from '${this.opts.appPackage}'. Original error: ${err.message}`);
       }
     }
 
     if (!await fs.exists(app)) {
-      log.info(`The app at '${app}' does not exist. Returning empty strings`);
-      return {};
+      log.errorAndThrow(`The app at '${app}' does not exist`);
     }
 
     try {
@@ -75,8 +72,7 @@ commands.getStrings = async function (language) {
       this.apkStrings[language] = apkStrings;
       return preprocessStringsMap(apkStrings);
     } catch (err) {
-      log.warn(`Cannot extract strings from '${app}'. Original error: ${err.message}`);
-      return {};
+      log.errorAndThrow(`Cannot extract strings from '${app}'. Original error: ${err.message}`);
     }
   } finally {
     await fs.rimraf(tmpRoot);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -380,12 +380,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
   }
 
   async initAUT () {
-    // set the localized strings for the current language from the apk
-    // TODO: incorporate changes from appium#5308 which fix a race cond-
-    // ition bug in old appium and need to be replicated here
-    this.apkStrings[this.opts.language] = await androidHelpers.pushStrings(
-        this.opts.language, this.adb, this.opts);
-
     // Install any "otherApps" that were specified in caps
     if (this.opts.otherApps) {
       let otherApps;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "appium-android-driver": "^4.0.0",
     "appium-base-driver": "^3.4.0",
     "appium-support": "^2.18.0",
-    "appium-uiautomator2-server": "^1.19.0",
+    "appium-uiautomator2-server": "^2.0.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
The original android-bootstrap component needs resource strings to be available as json on the destination device in order to "fix" element lookups. UIA2 server does not apply any fixes there, so there is no need to extract and upload strings json on session init. This change also allows to save a great amount of time. 

I'm going to delete the `/wd/hub/session/:sessionId/appium/app/strings` handler from UIA2 server, since it is a dummy implementation, which has absolutely no effect.