### PR TITLE
fix disabling animation

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -307,6 +307,25 @@ class AndroidUiautomator2Driver extends BaseDriver {
       this.caps.appPackage = appInfo.appPackage;
     }
 
+    // Should be after installing io.appium.settings
+    if (this.opts.disableWindowAnimation) {
+      // Granting android.permission.SET_ANIMATION_SCALE is necessary to handle animations under API level 26
+      // Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
+      // Maybe, `--no-window-animation` works over Android 8 to disable all of animations
+      if (await this.adb.getApiLevel() < 26) { // API level 26 is Android 8.0.
+
+        if (await this.adb.isAnimationOn()) {
+          // TODO: Replace settings and SET_ANIMATION_SCALE to const from appium-android-driver
+          await this.adb.grantPermission('io.appium.settings', 'android.permission.SET_ANIMATION_SCALE');
+          logger.info('Disabling window animation as it is requested by "disableWindowAnimation" capability');
+          await this.adb.setAnimationState(false);
+          this._wasWindowAnimationDisabled = true;
+        } else {
+          logger.info('Window animation is already disabled');
+        }
+      }
+    }
+
     // launch UiAutomator2 and wait till its online and we have a session
     await this.uiautomator2.startSession(this.caps);
 
@@ -509,6 +528,11 @@ class AndroidUiautomator2Driver extends BaseDriver {
         } catch (err) {
           logger.warn(`Unable to uninstall app: ${err.message}`);
         }
+      }
+      // This value can be true if test target device is <= 26
+      if (this._wasWindowAnimationDisabled) {
+        logger.info('Restoring window animation state');
+        await this.adb.setAnimationState(true);
       }
       await this.adb.stopLogcat();
       if (util.hasValue(this.opts.systemPort)) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -311,13 +311,10 @@ class AndroidUiautomator2Driver extends BaseDriver {
     if (this.opts.disableWindowAnimation) {
       // Granting android.permission.SET_ANIMATION_SCALE is necessary to handle animations under API level 26
       // Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
-      // Maybe, `--no-window-animation` works over Android 8 to disable all of animations
+      // `--no-window-animation` works over Android 8 to disable all of animations
       if (await this.adb.getApiLevel() < 26) { // API level 26 is Android 8.0.
-
         if (await this.adb.isAnimationOn()) {
-          // TODO: Replace settings and SET_ANIMATION_SCALE to const from appium-android-driver
-          await this.adb.grantPermission('io.appium.settings', 'android.permission.SET_ANIMATION_SCALE');
-          logger.info('Disabling window animation as it is requested by "disableWindowAnimation" capability');
+          logger.info('Disabling animation via io.appium.settings');
           await this.adb.setAnimationState(false);
           this._wasWindowAnimationDisabled = true;
         } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -308,18 +308,16 @@ class AndroidUiautomator2Driver extends BaseDriver {
     }
 
     // Should be after installing io.appium.settings
-    if (this.opts.disableWindowAnimation) {
+    if (this.opts.disableWindowAnimation && (await this.adb.getApiLevel() < 26)) { // API level 26 is Android 8.0.
       // Granting android.permission.SET_ANIMATION_SCALE is necessary to handle animations under API level 26
       // Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
       // `--no-window-animation` works over Android 8 to disable all of animations
-      if (await this.adb.getApiLevel() < 26) { // API level 26 is Android 8.0.
-        if (await this.adb.isAnimationOn()) {
-          logger.info('Disabling animation via io.appium.settings');
-          await this.adb.setAnimationState(false);
-          this._wasWindowAnimationDisabled = true;
-        } else {
-          logger.info('Window animation is already disabled');
-        }
+      if (await this.adb.isAnimationOn()) {
+        logger.info('Disabling animation via io.appium.settings');
+        await this.adb.setAnimationState(false);
+        this._wasWindowAnimationDisabled = true;
+      } else {
+        logger.info('Window animation is already disabled');
       }
     }
 


### PR DESCRIPTION
As mentioned in https://github.com/appium/appium/pull/11640#issuecomment-438260477 , `--no-window-animation` doesn't disable animation duration correctly. It disables only window and transtion animation. Over Android8, it works correctly though.

Let me consider https://github.com/appium/appium-android-driver/pull/464 and https://github.com/appium/appium-espresso-driver as well a bit.