### PR TITLE
Removed redundat UIAutomator processes killi during UIAutomator initialization

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -396,9 +396,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
     });
     this.proxyReqRes = this.uiautomator2.proxyReqRes.bind(this.uiautomator2);
 
-    // killing any uiautomator existing processes
-    await this.uiautomator2.killUiAutomatorOnDevice();
-
     await this.uiautomator2.installServerApk(this.opts.uiautomator2ServerInstallTimeout);
   }
 


### PR DESCRIPTION
Removed killing any existing UIAutomator2 processes running on device
during phase of UIAutomator2Server initialization, which is not required
at that point, due to possibility of re-installation apks. 

Processes are killed either way on the begging of session startup in function startSession in uiautomator2.js and I can't see the point in doing it twice.