### PR TITLE
Fixed duplicated chrome startup

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -334,8 +334,9 @@ class AndroidUiautomator2Driver extends BaseDriver {
       logger.debug(`'skipUnlock' capability set, so skipping device unlock`);
     }
 
-    // rescue UiAutomator2 if it fails to start our AUT
-    if (this.opts.autoLaunch) {
+    if (this.isChromeSession) { // start a chromedriver session
+      await this.startChromeSession(this);
+    } else if (this.opts.autoLaunch) { // rescue UiAutomator2 if it fails to start our AUT
       await this.ensureAppStarts();
     }
 
@@ -352,10 +353,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
       const timeout = this.opts.autoWebviewTimeout || 2000;
       logger.info(`Setting auto webview to context '${viewName}' with timeout ${timeout}ms`);
       await retryInterval(timeout / 500, 500, this.setContext.bind(this), viewName);
-    }
-
-    if (this.isChromeSession) {
-      await this.startChromeSession(this);
     }
 
     // now that everything has started successfully, turn on proxying so all


### PR DESCRIPTION
Fixed startup for web execution. Currently chrome browser is started
twice: firstly by ensureAppStarts and then by startChromeSession. 
I think it can be simplified and done similarly to solution implemented in
AndroidDriver.