### PR TITLE
Implement capability to skip server installation

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -32,7 +32,7 @@ let uiautomatorCapConstraints = {
   mjpegScreenshotUrl: {
     isString: true,
   },
-  skipUiAutomator2ServerInstallation: {
+  skipServerInstallation: {
     isBoolean: true
   }
 };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -32,6 +32,9 @@ let uiautomatorCapConstraints = {
   mjpegScreenshotUrl: {
     isString: true,
   },
+  skipUiAutomator2ServerInstallation: {
+    isBoolean: true
+  }
 };
 
 let desiredCapConstraints = {};

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -393,7 +393,11 @@ class AndroidUiautomator2Driver extends BaseDriver {
     });
     this.proxyReqRes = this.uiautomator2.proxyReqRes.bind(this.uiautomator2);
 
-    await this.uiautomator2.installServerApk(this.opts.uiautomator2ServerInstallTimeout);
+    if (!this.opts.skipUiAutomator2ServerInstallation) {
+      await this.uiautomator2.installServerApk(this.opts.uiautomator2ServerInstallTimeout);
+    } else {
+      logger.debug(`'skipUiAutomator2ServerInstallation' is set. Skipping UiAutomator2 server installation.`);
+    }
   }
 
   async initAUT () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -393,10 +393,10 @@ class AndroidUiautomator2Driver extends BaseDriver {
     });
     this.proxyReqRes = this.uiautomator2.proxyReqRes.bind(this.uiautomator2);
 
-    if (!this.opts.skipUiAutomator2ServerInstallation) {
-      await this.uiautomator2.installServerApk(this.opts.uiautomator2ServerInstallTimeout);
+    if (this.opts.skipServerInstallation) {
+      logger.info(`'skipServerInstallation' is set. Skipping UIAutomator2 server installation.`);
     } else {
-      logger.debug(`'skipUiAutomator2ServerInstallation' is set. Skipping UiAutomator2 server installation.`);
+      await this.uiautomator2.installServerApk(this.opts.uiautomator2ServerInstallTimeout);
     }
   }
 

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -129,11 +129,11 @@ class UiAutomator2Server {
     // kill any uiautomator existing processes
     await this.killUiAutomatorOnDevice();
 
-    if (!caps.skipUiAutomator2ServerInstallation) {
-      logger.info(`Starting uiautomator2 server ${serverVersion}`);
-      logger.info(`Using UIAutomator2 server from '${apkPath}' and test from '${testApkPath}'`);
+    if (caps.skipServerInstallation) {
+      logger.info(`'skipServerInstallation' is set. Attempting to use UIAutomator2 server from the device.`);
     } else {
-      logger.info(`'skipUiAutomator2ServerInstallation' is set. Attempt to use UiAutomator2 server from device.`);
+      logger.info(`Starting UIAutomator2 server ${serverVersion}`);
+      logger.info(`Using UIAutomator2 server from '${apkPath}' and test from '${testApkPath}'`);
     }
 
     // let cmd = ['am', 'instrument', '-w',

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -129,9 +129,12 @@ class UiAutomator2Server {
     // kill any uiautomator existing processes
     await this.killUiAutomatorOnDevice();
 
-    logger.info(`Starting uiautomator2 server ${serverVersion}`);
-
-    logger.info(`Using UIAutomator2 server from '${apkPath}' and test from '${testApkPath}'`);
+    if (!caps.skipUiAutomator2ServerInstallation) {
+      logger.info(`Starting uiautomator2 server ${serverVersion}`);
+      logger.info(`Using UIAutomator2 server from '${apkPath}' and test from '${testApkPath}'`);
+    } else {
+      logger.info(`'skipUiAutomator2ServerInstallation' is set. Attempt to use UiAutomator2 server from device.`);
+    }
 
     // let cmd = ['am', 'instrument', '-w',
     //   'io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner'];


### PR DESCRIPTION
New capability 'skipServerInstallation' is introduced in
order to allow user to skip UIAutomator2Server installation phase.
The installation and validation of currently installed versions can be
omitted if user is sure that applications in proper versions are already installed.
It allows for huge performance improvement (even about 50% in some cases). 