### PR TITLE
add re-installing a uia2 server when the newer version of uia2 server is on test device

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -68,6 +68,7 @@ class UiAutomator2Server {
       if (await this.adb.checkApkCert(appPath, appId)) {
         shouldUninstallServerPackages = shouldUninstallServerPackages || [
           this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
         ].includes(appState);
       } else {
         await this.adb.sign(appPath);


### PR DESCRIPTION
We'd like to re-install UIA2 server if installed UIA2 is not equal to running Appium server's UIA2.

In our use case, below case can happen.

- A user can use arbitrary Appium version
- test devices are in shared pool

Then,

1. User A uses Appium 1.10.0 on device X
2. User B uses Appium 1.11.0 on device X
3. User A uses Appium 1.10.0 on device X again
    - then, device X has a UIA2 bundled in Appium 1.11.0. Current logic does not downgrade the UIA2 on device X to the one bundled in Appium 1.10.0 since the UIA2 bundled in 1.11.0 is not `OLDER_VERSION_INSTALLED`. (The appium version is an example)
    - In this case, we would like to use UIA2 bundled in 1.10.0

We can skip installation phase only when UIA2 server on test device is the same as UIA2 Appium would like to use.

What do you think? @mykola-mokhnach 

related to: https://github.com/appium/appium-uiautomator2-driver/pull/262