### PR TITLE
Add tests for install/uninstall following the result of getApplicationInstallState

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -212,4 +212,5 @@ class UiAutomator2Server {
   }
 }
 
+export { UiAutomator2Server, INSTRUMENTATION_TARGET };
 export default UiAutomator2Server;

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -9,15 +9,13 @@ chai.use(chaiAsPromised);
 
 describe('UiAutomator2', function () {
   const adb = new ADB();
-
   describe('installServerApk', withMocks({adb}, (mocks) => {
     let uiautomator2;
     beforeEach(function () {
       uiautomator2 = new UiAutomator2Server({
-        adb: ADB.createADB(), tmpDir: 'tmp', systemPort: 4724,
+        adb, tmpDir: 'tmp', systemPort: 4724,
         host: 'localhost', devicePort: 6790, disableWindowAnimation: false
       });
-      uiautomator2.adb = adb;
     });
     afterEach(function () {
       mocks.verify();

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -2,14 +2,13 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { ADB } from 'appium-adb';
 import { withMocks } from 'appium-test-support';
-import UiAutomator2Server from '../../lib/uiautomator2';
+import { UiAutomator2Server, INSTRUMENTATION_TARGET } from '../../lib/uiautomator2';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('UiAutomator2', function () {
   const adb = new ADB();
-  const INSTRUMENTATION_TARGET = 'io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner';
 
   describe('installServerApk', withMocks({adb}, (mocks) => {
     let uiautomator2;
@@ -31,7 +30,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('checkApkCert').once().returns(true);
 
       // SERVER_TEST_PACKAGE_ID
-      mocks.adb.expects('checkApkCert').once().returns(true);
+      mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
       mocks.adb.expects('install').twice();
@@ -49,7 +48,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('checkApkCert').once().returns(true);
 
       // SERVER_TEST_PACKAGE_ID
-      mocks.adb.expects('checkApkCert').once().returns(true);
+      mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
       mocks.adb.expects('install').twice();
@@ -67,7 +66,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('checkApkCert').once().returns(true);
 
       // SERVER_TEST_PACKAGE_ID
-      mocks.adb.expects('checkApkCert').once().returns(true);
+      mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('uninstallApk').never();
       mocks.adb.expects('install').never();
@@ -86,8 +85,8 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('sign').once();
 
       // SERVER_TEST_PACKAGE_ID
-      mocks.adb.expects('checkApkCert').once().returns(false);
-      mocks.adb.expects('sign').once();
+      mocks.adb.expects('checkApkCert').twice().returns(false);
+      mocks.adb.expects('sign').twice();
       mocks.adb.expects('isAppInstalled').once().returns(false);
 
       mocks.adb.expects('uninstallApk').never();
@@ -98,7 +97,7 @@ describe('UiAutomator2', function () {
       await uiautomator2.installServerApk();
     });
 
-    it('new server and server.test are unknown', async function () {
+    it('version number of new server and server.test are unknown', async function () {
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.UNKNOWN);

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -65,6 +65,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED);
       mocks.adb.expects('checkApkCert').once().returns(true);
+
       // SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').once().returns(true);
 
@@ -98,9 +99,13 @@ describe('UiAutomator2', function () {
     });
 
     it('new server and server.test are unknown', async function () {
-      mocks.adb.expects('checkApkCert').twice().returns(true);
+      // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.UNKNOWN);
+      mocks.adb.expects('checkApkCert').once().returns(true);
+
+      // SERVER_TEST_PACKAGE_ID
+      mocks.adb.expects('checkApkCert').once().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
       mocks.adb.expects('install').twice();

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -27,9 +27,8 @@ describe('UiAutomator2', function () {
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED);
-      mocks.adb.expects('checkApkCert').once().returns(true);
 
-      // SERVER_TEST_PACKAGE_ID
+      // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
@@ -45,9 +44,8 @@ describe('UiAutomator2', function () {
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED);
-      mocks.adb.expects('checkApkCert').once().returns(true);
 
-      // SERVER_TEST_PACKAGE_ID
+      // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
@@ -63,9 +61,8 @@ describe('UiAutomator2', function () {
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED);
-      mocks.adb.expects('checkApkCert').once().returns(true);
 
-      // SERVER_TEST_PACKAGE_ID
+      // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('uninstallApk').never();
@@ -81,12 +78,12 @@ describe('UiAutomator2', function () {
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.NOT_INSTALLED);
-      mocks.adb.expects('checkApkCert').once().returns(false);
-      mocks.adb.expects('sign').once();
 
-      // SERVER_TEST_PACKAGE_ID
+      // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(false);
       mocks.adb.expects('sign').twice();
+
+      // SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('isAppInstalled').once().returns(false);
 
       mocks.adb.expects('uninstallApk').never();
@@ -97,14 +94,13 @@ describe('UiAutomator2', function () {
       await uiautomator2.installServerApk();
     });
 
-    it('version number of new server and server.test are unknown', async function () {
+    it('version numbers of new server and server.test are unknown', async function () {
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
         .returns(adb.APP_INSTALL_STATE.UNKNOWN);
-      mocks.adb.expects('checkApkCert').once().returns(true);
 
-      // SERVER_TEST_PACKAGE_ID
-      mocks.adb.expects('checkApkCert').once().returns(true);
+      // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
+      mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
       mocks.adb.expects('install').twice();

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -1,0 +1,114 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { ADB } from 'appium-adb';
+import { withMocks } from 'appium-test-support';
+import UiAutomator2Server from '../../lib/uiautomator2';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('UiAutomator2', function () {
+  const adb = new ADB();
+  const INSTRUMENTATION_TARGET = 'io.appium.uiautomator2.server.test/android.support.test.runner.AndroidJUnitRunner';
+
+  describe('installServerApk', withMocks({adb}, (mocks) => {
+    let uiautomator2;
+    beforeEach(function () {
+      uiautomator2 = new UiAutomator2Server({
+        adb: ADB.createADB(), tmpDir: 'tmp', systemPort: 4724,
+        host: 'localhost', devicePort: 6790, disableWindowAnimation: false
+      });
+      uiautomator2.adb = adb;
+    });
+    afterEach(function () {
+      mocks.verify();
+    });
+
+    it('new server and server.test are older than installed version', async function () {
+      // SERVER_PACKAGE_ID
+      mocks.adb.expects('getApplicationInstallState').once()
+        .returns(adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED);
+      mocks.adb.expects('checkApkCert').once().returns(true);
+
+      // SERVER_TEST_PACKAGE_ID
+      mocks.adb.expects('checkApkCert').once().returns(true);
+
+      mocks.adb.expects('uninstallApk').twice();
+      mocks.adb.expects('install').twice();
+
+      mocks.adb.expects('shell')
+        .withExactArgs(['pm', 'list', 'instrumentation'])
+        .once().returns(INSTRUMENTATION_TARGET);
+      await uiautomator2.installServerApk();
+    });
+
+    it('new server and server.test are newer than installed version', async function () {
+      // SERVER_PACKAGE_ID
+      mocks.adb.expects('getApplicationInstallState').once()
+        .returns(adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED);
+      mocks.adb.expects('checkApkCert').once().returns(true);
+
+      // SERVER_TEST_PACKAGE_ID
+      mocks.adb.expects('checkApkCert').once().returns(true);
+
+      mocks.adb.expects('uninstallApk').twice();
+      mocks.adb.expects('install').twice();
+
+      mocks.adb.expects('shell')
+        .withExactArgs(['pm', 'list', 'instrumentation'])
+        .once().returns(INSTRUMENTATION_TARGET);
+      await uiautomator2.installServerApk();
+    });
+
+    it('new server and server.test are the same as installed version', async function () {
+      // SERVER_PACKAGE_ID
+      mocks.adb.expects('getApplicationInstallState').once()
+        .returns(adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED);
+      mocks.adb.expects('checkApkCert').once().returns(true);
+      // SERVER_TEST_PACKAGE_ID
+      mocks.adb.expects('checkApkCert').once().returns(true);
+
+      mocks.adb.expects('uninstallApk').never();
+      mocks.adb.expects('install').never();
+
+      mocks.adb.expects('shell')
+        .withExactArgs(['pm', 'list', 'instrumentation'])
+        .once().returns(INSTRUMENTATION_TARGET);
+      await uiautomator2.installServerApk();
+    });
+
+    it('new server and server.test are not installed', async function () {
+      // SERVER_PACKAGE_ID
+      mocks.adb.expects('getApplicationInstallState').once()
+        .returns(adb.APP_INSTALL_STATE.NOT_INSTALLED);
+      mocks.adb.expects('checkApkCert').once().returns(false);
+      mocks.adb.expects('sign').once();
+
+      // SERVER_TEST_PACKAGE_ID
+      mocks.adb.expects('checkApkCert').once().returns(false);
+      mocks.adb.expects('sign').once();
+      mocks.adb.expects('isAppInstalled').once().returns(false);
+
+      mocks.adb.expects('uninstallApk').never();
+      mocks.adb.expects('install').twice();
+
+      mocks.adb.expects('shell').withExactArgs(['pm', 'list', 'instrumentation'])
+        .once().returns(INSTRUMENTATION_TARGET);
+      await uiautomator2.installServerApk();
+    });
+
+    it('new server and server.test are unknown', async function () {
+      mocks.adb.expects('checkApkCert').twice().returns(true);
+      mocks.adb.expects('getApplicationInstallState').once()
+        .returns(adb.APP_INSTALL_STATE.UNKNOWN);
+
+      mocks.adb.expects('uninstallApk').twice();
+      mocks.adb.expects('install').twice();
+
+      mocks.adb.expects('shell')
+        .withExactArgs(['pm', 'list', 'instrumentation'])
+        .once().returns(INSTRUMENTATION_TARGET);
+      await uiautomator2.installServerApk();
+    });
+  }));
+});


### PR DESCRIPTION
Tests for making sure install/uninstall logic depends on `getApplicationInstallState`
Related to: https://github.com/appium/appium-uiautomator2-driver/pull/270