### PR TITLE
Improve am service pinging logic

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -136,6 +136,7 @@ class UiAutomator2Server {
             amError = e;
             stdout = e.stdout;
           }
+          // Check if the printed exit code equals to zero
           if (parseInt(stdout, 10) === 0) {
             log.debug('Activity manager service is available');
             isAmServiceAvailable = true;

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -129,12 +129,17 @@ class UiAutomator2Server {
         if (!isAmServiceAvailable) {
           // https://travis-ci.org/appium/appium-uiautomator2-driver/jobs/478514097#L4806
           amError = null;
+          let stdout;
           try {
-            await this.adb.shell(['am']);
-            log.debug('Activity manager service is available');
-            isAmServiceAvailable = true;
+            stdout = await this.adb.shell(['am stack list > /dev/null;echo $?']);
           } catch (e) {
             amError = e;
+            stdout = e.stdout;
+          }
+          if (parseInt(stdout, 10) === 0) {
+            log.debug('Activity manager service is available');
+            isAmServiceAvailable = true;
+            amError = null;
           }
         }
         return isPmServiceAvailable && isAmServiceAvailable;


### PR DESCRIPTION
We cannot rely on the exit code which is returned to the host, so I switched the logic to verify the original exit code received directly from adb shell. Thanks to @KazuCocoa for pointing that out