### PR TITLE
Remove am service state verification

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -101,10 +101,8 @@ class UiAutomator2Server {
   async verifyServicesAvailability () {
     log.debug(`Waiting up to ${SERVICES_LAUNCH_TIMEOUT}ms for services to be available`);
     let isPmServiceAvailable = false;
-    let isAmServiceAvailable = false;
     let pmOutput = '';
     let pmError = null;
-    let amError = null;
     try {
       await waitForCondition(async () => {
         if (!isPmServiceAvailable) {
@@ -126,42 +124,17 @@ class UiAutomator2Server {
             pmError = new Error('The instrumentation target is not listed by Package Manager');
           }
         }
-        if (!isAmServiceAvailable) {
-          // https://travis-ci.org/appium/appium-uiautomator2-driver/jobs/478514097#L4806
-          amError = null;
-          let stdout;
-          try {
-            stdout = await this.adb.shell(['am stack list > /dev/null;echo $?']);
-          } catch (e) {
-            amError = e;
-            stdout = e.stdout;
-          }
-          // Check if the printed exit code equals to zero
-          if (parseInt(stdout, 10) === 0) {
-            log.debug('Activity manager service is available');
-            isAmServiceAvailable = true;
-            amError = null;
-          }
-        }
-        return isPmServiceAvailable && isAmServiceAvailable;
+        return isPmServiceAvailable;
       }, {
         waitMs: SERVICES_LAUNCH_TIMEOUT,
         intervalMs: 1000,
       });
     } catch (err) {
-      if (!isPmServiceAvailable) {
-        log.error(`Unable to find instrumentation target '${INSTRUMENTATION_TARGET}': ${(pmError || {}).message}`);
-        if (pmOutput) {
-          log.debug('Available targets:');
-          for (const line of pmOutput.split('\n')) {
-            log.debug(`    ${line.replace('instrumentation:', '')}`);
-          }
-        }
-      }
-      if (!isAmServiceAvailable) {
-        log.error(`Activity manager service is not available`);
-        if (amError) {
-          log.debug(amError.message);
+      log.error(`Unable to find instrumentation target '${INSTRUMENTATION_TARGET}': ${(pmError || {}).message}`);
+      if (pmOutput) {
+        log.debug('Available targets:');
+        for (const line of pmOutput.split('\n')) {
+          log.debug(`    ${line.replace('instrumentation:', '')}`);
         }
       }
     }


### PR DESCRIPTION
It seems like there is no good way to healthcheck am service state. Let's just rely on the delay between instruments startup retries.

https://github.com/appium/appium-uiautomator2-driver/pull/281#issuecomment-456671943