### PR TITLE
move disabling animation before autoLaunch check

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -292,18 +292,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
     logger.debug(`Forwarding UiAutomator2 Server port ${DEVICE_PORT} to ${this.opts.systemPort}`);
     await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
 
-    // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
-    if (this.opts.autoLaunch) {
-      // set up app under test
-      // prepare our actual AUT, get it on the device, etc...
-      await this.initAUT();
-    }
-    // Adding AUT package name in the capabilities if package name not exist in caps
-    if (!this.caps.appPackage && appInfo) {
-      this.caps.appPackage = appInfo.appPackage;
-    }
-
-    // Should be after installing io.appium.settings
+    // Should be after installing io.appium.settings in helpers.initDevice
     if (this.opts.disableWindowAnimation && (await this.adb.getApiLevel() < 26)) { // API level 26 is Android 8.0.
       // Granting android.permission.SET_ANIMATION_SCALE is necessary to handle animations under API level 26
       // Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
@@ -315,6 +304,17 @@ class AndroidUiautomator2Driver extends BaseDriver {
       } else {
         logger.info('Window animation is already disabled');
       }
+    }
+    
+    // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
+    if (this.opts.autoLaunch) {
+      // set up app under test
+      // prepare our actual AUT, get it on the device, etc...
+      await this.initAUT();
+    }
+    // Adding AUT package name in the capabilities if package name not exist in caps
+    if (!this.caps.appPackage && appInfo) {
+      this.caps.appPackage = appInfo.appPackage;
     }
 
     // launch UiAutomator2 and wait till its online and we have a session

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -305,7 +305,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
         logger.info('Window animation is already disabled');
       }
     }
-    
+
     // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
     if (this.opts.autoLaunch) {
       // set up app under test


### PR DESCRIPTION
Only espresso driver calls disabling/enabling animation before `this.initAUT();`
UIA2 can also follow it