### PR TITLE
Verify file system permissions before signing files

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -423,13 +423,10 @@ class AndroidUiautomator2Driver extends BaseDriver {
     if (!this.opts.skipUninstall) {
       await this.adb.uninstallApk(this.opts.appPackage);
     }
-    if (!this.opts.noSign) {
-      let signed = await this.adb.checkApkCert(this.opts.app, this.opts.appPackage);
-      if (!signed && this.opts.app) {
-        await this.adb.sign(this.opts.app, this.opts.appPackage);
-      }
-    }
     if (this.opts.app) {
+      if (!this.opts.noSign && !await this.adb.checkApkCert(this.opts.app, this.opts.appPackage)) {
+        await helpers.signApp(this.adb, this.opts.app);
+      }
       await helpers.installApk(this.adb, this.opts);
     }
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,7 @@
+import path from 'path';
+import _fs from 'fs';
+import { fs } from 'appium-support';
+
 let helpers = {};
 
 helpers.ensureInternetPermissionForApp = async function (adb, app) {
@@ -10,6 +14,17 @@ helpers.ensureInternetPermissionForApp = async function (adb, app) {
             '<uses-permission android:name="android.**permission.INTERNET"/>' +
             'in your AndroidManifest.xml';
   throw new Error(msg);
+};
+
+helpers.signApp = async function (adb, appPath) {
+  try {
+    await fs.access(appPath, _fs.W_OK);
+  } catch (e) {
+    throw new Error(`The application at '${appPath}' is not writeable. ` +
+      `Please grant write permissions to this file or to its parent folder '${path.dirname(appPath)}' ` +
+      `for the Appium process, so it could sign the application`);
+  }
+  await adb.sign(appPath);
 };
 
 export default helpers;

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -5,7 +5,7 @@ import log from './logger';
 import { SERVER_APK_PATH as apkPath, TEST_APK_PATH as testApkPath, version as serverVersion } from 'appium-uiautomator2-server';
 import { util, logger } from 'appium-support';
 import B from 'bluebird';
-
+import helpers from './helpers';
 
 const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'disableWindowAnimation'];
 const SERVER_LAUNCH_TIMEOUT = 30000;
@@ -50,7 +50,7 @@ class UiAutomator2Server {
         // There is no point in getting the state for test server,
         // since it does not contain version info
         if (!await this.adb.checkApkCert(appPath, appId)) {
-          await this.adb.sign(appPath);
+          await helpers.signApp(this.adb, appPath);
           shouldUninstallServerPackages = shouldUninstallServerPackages
             || await this.adb.isAppInstalled(appId);
           shouldInstallServerPackages = true;
@@ -66,7 +66,7 @@ class UiAutomator2Server {
           this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
         ].includes(appState);
       } else {
-        await this.adb.sign(appPath);
+        await helpers.signApp(this.adb, appPath);
         shouldUninstallServerPackages = shouldUninstallServerPackages || ![
           this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
         ].includes(appState);


### PR DESCRIPTION
I see users are confused by standard signer errors, which are happening because of missing FS permissions. This PR adds a separate verification of the fact that the destination file is writeable prior to sign it and raises a proper error message.