### PR TITLE
Add a better error message if no free port is found

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -196,7 +196,14 @@ class AndroidUiautomator2Driver extends BaseDriver {
             `${this.opts.appPackage} directly on the device`);
         await this.checkPackagePresent();
       }
-      this.opts.systemPort = this.opts.systemPort || await findAPortNotInUse(SYSTEM_PORT_RANGE[0], SYSTEM_PORT_RANGE[1]);
+      try {
+        this.opts.systemPort = this.opts.systemPort || await findAPortNotInUse(SYSTEM_PORT_RANGE[0], SYSTEM_PORT_RANGE[1]);
+      } catch (e) {
+        logger.errorAndThrow(`Cannot find any free port in range ${_.first(SYSTEM_PORT_RANGE)}..${_.last(SYSTEM_PORT_RANGE)}}. ` +
+          `Please set the available port number by providing the systemPort capability or ` +
+          `double check the processes that are locking ports within this range and terminate ` +
+          `these which are not needed anymore`);
+      }
       this.opts.adbPort = this.opts.adbPort || DEFAULT_ADB_PORT;
 
       await this.startUiAutomator2Session();


### PR DESCRIPTION
The current `No open port found` error message is not very helpful.