### PR TITLE
fix no only test package case

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -47,7 +47,7 @@ class UiAutomator2Server {
     let shouldInstallServerPackages = false;
     for (const {appId, appPath} of packagesInfo) {
       if (appId === SERVER_TEST_PACKAGE_ID) {
-        const isAppInstalled = false;// await this.adb.isAppInstalled(appId);
+        const isAppInstalled = await this.adb.isAppInstalled(appId);
 
         // There is no point in getting the state for test server,
         // since it does not contain version info

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -262,5 +262,5 @@ class UiAutomator2Server {
   }
 }
 
-export { UiAutomator2Server, INSTRUMENTATION_TARGET };
+export { UiAutomator2Server, INSTRUMENTATION_TARGET, SERVER_TEST_PACKAGE_ID };
 export default UiAutomator2Server;

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -47,12 +47,17 @@ class UiAutomator2Server {
     let shouldInstallServerPackages = false;
     for (const {appId, appPath} of packagesInfo) {
       if (appId === SERVER_TEST_PACKAGE_ID) {
+        const isAppInstalled = await this.adb.isAppInstalled(appId);
+
         // There is no point in getting the state for test server,
         // since it does not contain version info
         if (!await this.adb.checkApkCert(appPath, appId)) {
           await helpers.signApp(this.adb, appPath);
-          shouldUninstallServerPackages = shouldUninstallServerPackages
-            || await this.adb.isAppInstalled(appId);
+          shouldUninstallServerPackages = shouldUninstallServerPackages || isAppInstalled;
+          shouldInstallServerPackages = true;
+        }
+
+        if (!isAppInstalled) {
           shouldInstallServerPackages = true;
         }
         continue;

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -47,7 +47,7 @@ class UiAutomator2Server {
     let shouldInstallServerPackages = false;
     for (const {appId, appPath} of packagesInfo) {
       if (appId === SERVER_TEST_PACKAGE_ID) {
-        const isAppInstalled = await this.adb.isAppInstalled(appId);
+        const isAppInstalled = false;// await this.adb.isAppInstalled(appId);
 
         // There is no point in getting the state for test server,
         // since it does not contain version info

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -32,6 +32,10 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('uninstallApk').twice();
       mocks.adb.expects('install').twice();
 
+      mocks.adb.expects('isAppInstalled')
+        .withExactArgs('io.appium.uiautomator2.server.test')
+        .once().returns(true);
+
       mocks.adb.expects('shell')
         .withExactArgs(['pm', 'list', 'instrumentation'])
         .once().returns(INSTRUMENTATION_TARGET);
@@ -45,6 +49,10 @@ describe('UiAutomator2', function () {
 
       // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
+
+      mocks.adb.expects('isAppInstalled')
+        .withExactArgs('io.appium.uiautomator2.server.test')
+        .once().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
       mocks.adb.expects('install').twice();
@@ -62,6 +70,10 @@ describe('UiAutomator2', function () {
 
       // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
+
+      mocks.adb.expects('isAppInstalled')
+        .withExactArgs('io.appium.uiautomator2.server.test')
+        .once().returns(true);
 
       mocks.adb.expects('uninstallApk').never();
       mocks.adb.expects('install').never();
@@ -82,7 +94,9 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('sign').twice();
 
       // SERVER_TEST_PACKAGE_ID
-      mocks.adb.expects('isAppInstalled').once().returns(false);
+      mocks.adb.expects('isAppInstalled')
+        .withExactArgs('io.appium.uiautomator2.server.test')
+        .once().returns(false);
 
       mocks.adb.expects('uninstallApk').never();
       mocks.adb.expects('install').twice();
@@ -100,7 +114,33 @@ describe('UiAutomator2', function () {
       // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
+      mocks.adb.expects('isAppInstalled')
+        .withExactArgs('io.appium.uiautomator2.server.test')
+        .once().returns(false);
+
       mocks.adb.expects('uninstallApk').twice();
+      mocks.adb.expects('install').twice();
+
+      mocks.adb.expects('shell')
+        .withExactArgs(['pm', 'list', 'instrumentation'])
+        .once().returns(INSTRUMENTATION_TARGET);
+      await uiautomator2.installServerApk();
+    });
+
+
+    it('a server is installed but server.test is not', async function () {
+      // SERVER_PACKAGE_ID
+      mocks.adb.expects('getApplicationInstallState').once()
+        .returns(adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED);
+
+      // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
+      mocks.adb.expects('checkApkCert').twice().returns(true);
+
+      mocks.adb.expects('isAppInstalled')
+        .withExactArgs('io.appium.uiautomator2.server.test')
+        .once().returns(false);
+
+      mocks.adb.expects('uninstallApk').never();
       mocks.adb.expects('install').twice();
 
       mocks.adb.expects('shell')

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -2,7 +2,8 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { ADB } from 'appium-adb';
 import { withMocks } from 'appium-test-support';
-import { UiAutomator2Server, INSTRUMENTATION_TARGET } from '../../lib/uiautomator2';
+import { UiAutomator2Server, INSTRUMENTATION_TARGET,
+         SERVER_TEST_PACKAGE_ID } from '../../lib/uiautomator2';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -33,7 +34,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('install').twice();
 
       mocks.adb.expects('isAppInstalled')
-        .withExactArgs('io.appium.uiautomator2.server.test')
+        .withExactArgs(SERVER_TEST_PACKAGE_ID)
         .once().returns(true);
 
       mocks.adb.expects('shell')
@@ -51,7 +52,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('isAppInstalled')
-        .withExactArgs('io.appium.uiautomator2.server.test')
+        .withExactArgs(SERVER_TEST_PACKAGE_ID)
         .once().returns(true);
 
       mocks.adb.expects('uninstallApk').twice();
@@ -72,7 +73,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('isAppInstalled')
-        .withExactArgs('io.appium.uiautomator2.server.test')
+        .withExactArgs(SERVER_TEST_PACKAGE_ID)
         .once().returns(true);
 
       mocks.adb.expects('uninstallApk').never();
@@ -95,7 +96,7 @@ describe('UiAutomator2', function () {
 
       // SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('isAppInstalled')
-        .withExactArgs('io.appium.uiautomator2.server.test')
+        .withExactArgs(SERVER_TEST_PACKAGE_ID)
         .once().returns(false);
 
       mocks.adb.expects('uninstallApk').never();
@@ -115,7 +116,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('isAppInstalled')
-        .withExactArgs('io.appium.uiautomator2.server.test')
+        .withExactArgs(SERVER_TEST_PACKAGE_ID)
         .once().returns(false);
 
       mocks.adb.expects('uninstallApk').twice();
@@ -137,7 +138,7 @@ describe('UiAutomator2', function () {
       mocks.adb.expects('checkApkCert').twice().returns(true);
 
       mocks.adb.expects('isAppInstalled')
-        .withExactArgs('io.appium.uiautomator2.server.test')
+        .withExactArgs(SERVER_TEST_PACKAGE_ID)
         .once().returns(false);
 
       mocks.adb.expects('uninstallApk').never();


### PR DESCRIPTION
I faced the below case. Then, I must uninstall SERVER_PACKAGE_ID by manual to fix the issue. Without the uninstallation, never Appium becomes health.

- SERVER_TEST_PACKAGE_ID is not in a test device
- SERVER_PACKAGE_ID is in the test device
   - and SAME_VERSION_INSTALLED

Thus, I would like to enable `shouldInstallServerPackages` if the test device has no `test` package.
This case is not so common. So, I just enable it instead of separate the logic for SERVER_TEST_PACKAGE_ID and SERVER_PACKAGE_ID.