### PR TITLE
Improve session leftovers cleanup

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -6,6 +6,7 @@ import { SERVER_APK_PATH as apkPath, TEST_APK_PATH as testApkPath, version as se
 import { util, logger } from 'appium-support';
 import B from 'bluebird';
 import helpers from './helpers';
+import request from 'request-promise';
 
 const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'disableWindowAnimation'];
 const SERVER_LAUNCH_TIMEOUT = 30000;
@@ -232,7 +233,7 @@ class UiAutomator2Server {
         onExit();
       }
     });
-    await instrumentationProcess.start(3000);
+    await instrumentationProcess.start(1000);
   }
 
   async deleteSession () {
@@ -249,6 +250,31 @@ class UiAutomator2Server {
 
   async cleanupAutomationLeftovers (strictCleanup = false) {
     log.debug(`Performing ${strictCleanup ? 'strict' : 'shallow'} cleanup of automation leftovers`);
+
+    try {
+      const {body} = await request.get({
+        url: `http://${this.host}:${this.systemPort}/wd/hub/sessions`,
+        timeout: 500,
+        resolveWithFullResponse: true,
+      });
+      const activeSessionIds = JSON.parse(body).map((sess) => sess.id);
+      if (activeSessionIds.length) {
+        log.debug(`The following obsolete sessions are still running: ${JSON.stringify(activeSessionIds)}`);
+        log.debug('Cleaning up the obsolete sessions');
+        await B.all(activeSessionIds.map((id) =>
+          request.delete({
+            url: `http://${this.host}:${this.systemPort}/wd/hub/session/${id}`,
+          })
+        ));
+        // Let all sessions to be properly terminated before continuing
+        await B.delay(1000);
+      } else {
+        log.debug('No obsolete sessions have been detected');
+      }
+    } catch (e) {
+      log.debug(`No obsolete sessions have been detected (${e.message})`);
+    }
+
     try {
       await this.adb.forceStop(SERVER_TEST_PACKAGE_ID);
     } catch (ignore) {}

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -252,15 +252,14 @@ class UiAutomator2Server {
     log.debug(`Performing ${strictCleanup ? 'strict' : 'shallow'} cleanup of automation leftovers`);
 
     try {
-      const {body} = await request.get({
+      const body = await request.get({
         url: `http://${this.host}:${this.systemPort}/wd/hub/sessions`,
         timeout: 500,
-        resolveWithFullResponse: true,
         json: true,
       });
+      log.debug(`The following obsolete sessions are still running: ${JSON.stringify(body)}`);
       const activeSessionIds = body.map((sess) => sess.id);
       if (activeSessionIds.length) {
-        log.debug(`The following obsolete sessions are still running: ${JSON.stringify(activeSessionIds)}`);
         log.debug('Cleaning up the obsolete sessions');
         await B.all(activeSessionIds.map((id) =>
           request.delete({

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -252,14 +252,14 @@ class UiAutomator2Server {
     log.debug(`Performing ${strictCleanup ? 'strict' : 'shallow'} cleanup of automation leftovers`);
 
     try {
-      const body = await request.get({
+      const {value} = await request.get({
         url: `http://${this.host}:${this.systemPort}/wd/hub/sessions`,
         timeout: 500,
         json: true,
       });
-      log.debug(`The following obsolete sessions are still running: ${JSON.stringify(body)}`);
-      const activeSessionIds = body.map((sess) => sess.id);
+      const activeSessionIds = value.map((sess) => sess.id);
       if (activeSessionIds.length) {
+        log.debug(`The following obsolete sessions are still running: ${JSON.stringify(activeSessionIds)}`);
         log.debug('Cleaning up the obsolete sessions');
         await B.all(activeSessionIds.map((id) =>
           request.delete({

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -256,8 +256,9 @@ class UiAutomator2Server {
         url: `http://${this.host}:${this.systemPort}/wd/hub/sessions`,
         timeout: 500,
         resolveWithFullResponse: true,
+        json: true,
       });
-      const activeSessionIds = JSON.parse(body).map((sess) => sess.id);
+      const activeSessionIds = body.map((sess) => sess.id);
       if (activeSessionIds.length) {
         log.debug(`The following obsolete sessions are still running: ${JSON.stringify(activeSessionIds)}`);
         log.debug('Cleaning up the obsolete sessions');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "appium-android-driver": "^4.0.0",
     "appium-base-driver": "^3.10.0",
     "appium-support": "^2.24.0",
-    "appium-uiautomator2-server": "^3.2.1",
+    "appium-uiautomator2-server": "^3.4.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This PR adds an additional step, which verifies if there are any obsolete sessions running on the device  and sends the DELETE command to them in order to properly shutdown UIA2 server process before starting a new one.

@KazuCocoa Can you please try your magic scenario with "double" session creation with this PR?