### PR TITLE
Add handling of gpsEnabled cap

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -279,6 +279,16 @@ class AndroidUiautomator2Driver extends BaseDriver {
       await this.adb.setHiddenApiPolicy('1');
     }
 
+    // check if we have to enable/disable gps before running the application
+    if (util.hasValue(this.opts.gpsEnabled)) {
+      if (this.isEmulator()) {
+        logger.info(`Trying to ${this.opts.gpsEnabled ? 'enable' : 'disable'} gps location provider`);
+        await this.adb.toggleGPSLocationProvider(this.opts.gpsEnabled);
+      } else {
+        logger.warn(`Sorry! 'gpsEnabled' capability is only available for emulators`);
+      }
+    }
+
     // get appPackage et al from manifest if necessary
     let appInfo = await helpers.getLaunchInfo(this.adb, this.opts);
     // and get it onto our 'opts' object so we use it from now on


### PR DESCRIPTION
Add code from `appium-android-driver` to support the `gpsEnabled` desired capability.