### PR TITLE
add timezone and locale in deviceinfo

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -202,11 +202,42 @@ helpers.suspendChromedriverProxy = function () {
 };
 
 /**
+ * @typedef {Object} DeviceInfo
+ *
+ * @property {?string} currentLocale - Current device locale. e.g. 'ja_EN' and 'zh-Hant_US'
+ * @property {?string} timeZone - TZ database Time Zones format like 'US/Pacific'
+ */
+
+/**
  * The list of available info entries can be found at
- * https://github.com/appium/appium-uiautomator2-server/blob/master/app/src/main/java/io/appium/uiautomator2/handler/GetDeviceInfo.java
+ * https://github.com/appium/appium-uiautomator2-server/blob/master/app/src/main/java/io/appium/uiautomator2/handler/GetDeviceInfo.java,
+ * device locale and timezone
+ *
+ * @returns {DeviceInfo} The current device info
+ * @throws {Error} if an error raised by command
  */
 commands.mobileGetDeviceInfo = async function () {
-  return await this.uiautomator2.jwproxy.command('/appium/device/info', 'GET');
+  let info = {};
+
+  try {
+    info = await this.uiautomator2.jwproxy.command('/appium/device/info', 'GET');
+  } catch (e) {
+    log.warn(`Failed to get device info by uiautomator2 server: '${e.message}'`);
+  }
+
+  try {
+    info.locale = await this.adb.getDeviceLocale();
+  } catch (e) {
+    log.warn(`Failed to get device locale: ${e.message}`);
+  }
+
+  try {
+    info.timeZone = await this.adb.getTimeZone();
+  } catch (e) {
+    log.warn(`Failed to get device timezone: ${e.message}`);
+  }
+
+  return info;
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -204,6 +204,7 @@ helpers.suspendChromedriverProxy = function () {
 /**
  * @typedef {Object} DeviceInfo
  *
+ * @property {Object} * The result of '/appium/device/info' by UIAutomator2 server
  * @property {?string} currentLocale - Current device locale. e.g. 'ja_EN' and 'zh-Hant_US'
  * @property {?string} timeZone - TZ database Time Zones format like 'US/Pacific'
  */
@@ -217,26 +218,9 @@ helpers.suspendChromedriverProxy = function () {
  * @throws {Error} if an error raised by command
  */
 commands.mobileGetDeviceInfo = async function () {
-  let info = {};
-
-  try {
-    info = await this.uiautomator2.jwproxy.command('/appium/device/info', 'GET');
-  } catch (e) {
-    log.warn(`Failed to get device info by uiautomator2 server: '${e.message}'`);
-  }
-
-  try {
-    info.locale = await this.adb.getDeviceLocale();
-  } catch (e) {
-    log.warn(`Failed to get device locale: ${e.message}`);
-  }
-
-  try {
-    info.timeZone = await this.adb.getTimeZone();
-  } catch (e) {
-    log.warn(`Failed to get device timezone: ${e.message}`);
-  }
-
+  const info = await this.uiautomator2.jwproxy.command('/appium/device/info', 'GET');
+  info.locale = await this.adb.getDeviceLocale();
+  info.timeZone = await this.adb.getTimeZone();
   return info;
 };
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^7.4.0",
+    "appium-adb": "^7.10.0",
     "appium-android-driver": "^4.10.0",
     "appium-base-driver": "^3.10.0",
     "appium-support": "^2.24.0",

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -27,4 +27,48 @@ describe('General', function () {
       result.y.should.be.equal(0);
     });
   });
+
+  describe('mobileGetDeviceInfo', function () {
+    driver = new AndroidUiautomator2Driver({}, false);
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should device all info', async function () {
+      driver.uiautomator2 = {jwproxy: {command: () => {}}};
+      const proxyStub = sinon.stub(driver.uiautomator2.jwproxy, 'command');
+      proxyStub.returns({model: 'Android SDK built for x86_64'});
+
+      driver.adb = {
+        getDeviceLocale: () => {},
+        getTimeZone: () => {},
+      };
+      sinon.stub(driver.adb, 'getDeviceLocale').returns('ja_EN');
+      sinon.stub(driver.adb, 'getTimeZone').returns('US/Pacific');
+
+      const out = await driver.mobileGetDeviceInfo();
+      out.model.should.eq('Android SDK built for x86_64');
+      out.locale.should.eq('ja_EN');
+      out.timeZone.should.eq('US/Pacific');
+    });
+
+    it('should device without locale and timeZone', async function () {
+      driver.uiautomator2 = {jwproxy: {command: () => {}}};
+      const proxyStub = sinon.stub(driver.uiautomator2.jwproxy, 'command');
+      proxyStub.returns({model: 'Android SDK built for x86_64'});
+
+      driver.adb = {
+        getDeviceLocale: () => {},
+        getTimeZone: () => {},
+      };
+      const proxyStub2 = sinon.stub(driver.adb, 'getDeviceLocale');
+      proxyStub2.throws();
+
+      const proxyStub3 = sinon.stub(driver.adb, 'getTimeZone');
+      proxyStub3.throws();
+
+      await driver.mobileGetDeviceInfo().should.eventually.be.rejected;
+    });
+  });
 });


### PR DESCRIPTION
Add `locale` and `timeZone` as a part of `deviceInfo` mobile command

```
@driver.execute_script 'mobile: deviceInfo', {}
=> {"androidId"=>"918a8c16d0e7c7ec",
 "manufacturer"=>"Google",
 "model"=>"Android SDK built for x86_64",
 "brand"=>"google",
 "apiVersion"=>"28",
 "platformVersion"=>"9",
 "carrierName"=>"Android",
 "realDisplaySize"=>"1080x1920",
 "displayDensity"=>420,
 "networks"=>
  [{"type"=>0,
    "typeName"=>"MOBILE",
    "subtype"=>13,
    "subtypeName"=>"LTE",
    "isConnected"=>true,
    "detailedState"=>"CONNECTED",
    "state"=>"CONNECTED",
    "extraInfo"=>"epc.tmobile.com",
    "isAvailable"=>true,
    "isFailover"=>false,
    "isRoaming"=>false,
    "capabilities"=>{"transportTypes"=>"NET_CAPABILITY_MMS", "networkCapabilities"=>"", "linkUpstreamBandwidthKbps"=>51200, "linkDownBandwidthKbps"=>102400, "signalStrength"=>-2147483648, "networkSpecifier"=>"1", "SSID"=>nil}},
   {"type"=>1,
    "typeName"=>"WIFI",
    "subtype"=>0,
    "subtypeName"=>"",
    "isConnected"=>true,
    "detailedState"=>"CONNECTED",
    "state"=>"CONNECTED",
    "extraInfo"=>nil,
    "isAvailable"=>true,
    "isFailover"=>false,
    "isRoaming"=>false,
    "capabilities"=>{"transportTypes"=>"NET_CAPABILITY_SUPL", "networkCapabilities"=>"", "linkUpstreamBandwidthKbps"=>1048576, "linkDownBandwidthKbps"=>1048576, "signalStrength"=>-50, "networkSpecifier"=>nil, "SSID"=>nil}}],
 "locale"=>"en-US",
 "timeZone"=>"Asia/Tokyo"}
```
