### PR TITLE
feat: add a capability of waitForLaunch

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -37,6 +37,9 @@ let uiautomatorCapConstraints = {
   },
   androidCoverageEndIntent: {
     isString: true
+  },
+  appWaitForLaunch: {
+    isBoolean: true
   }
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -479,6 +479,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
         flags: this.opts.intentFlags,
         waitPkg: this.opts.appWaitPackage,
         waitActivity: this.opts.appWaitActivity,
+        waitForLaunch: this.opts.appWaitForLaunch,
         optionalIntentArguments: this.opts.optionalIntentArguments,
         stopApp: !this.opts.dontStopAppOnReset,
         retry: true

--- a/test/functional/commands/general/mobile-command-e2e-specs.js
+++ b/test/functional/commands/general/mobile-command-e2e-specs.js
@@ -28,7 +28,7 @@ describe('mobile', function () {
       try {
         await driver.execute('mobile: shell', {command: 'echo', args: ['hello']});
       } catch (e) {
-        e.message.should.match(/Original error: Appium server must have relaxed security flag set in order to run any shell commands/);
+        e.message.should.match(/Potentially insecure feature 'adb_shell' has not been enabled/);
       }
     });
   });


### PR DESCRIPTION
Closes https://github.com/appium/appium/issues/12962

appium-adb already has an option, `waitForLaunch`, to remove `-W` for instrument command.
`waitForLaunch` is true by default.

This PR add the ability for UIA2.

- With `appWaitForLaunch`

```
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell am start -n io.appium.android.apis/io.appium.android.apis.ApiDemos -S -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -f 0x10200000'
```

- Without `appWaitForLaunch` (or true)

```
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell am start -W -n io.appium.android.apis/io.appium.android.apis.ApiDemos -S -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -f 0x10200000'
```

---

Espresso driver does not call `startApp`, so this change is needed for this repo.