### PR TITLE
fix: Copy server apks into temporary writeable location as a workaround

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import _fs from 'fs';
 import { fs } from 'appium-support';
 
 let helpers = {};
@@ -16,10 +15,17 @@ helpers.ensureInternetPermissionForApp = async function (adb, app) {
   throw new Error(msg);
 };
 
-helpers.signApp = async function (adb, appPath) {
+helpers.isWriteable = async function isWriteable (appPath) {
   try {
-    await fs.access(appPath, _fs.W_OK);
+    await fs.access(appPath, fs.W_OK);
+    return true;
   } catch (e) {
+    return false;
+  }
+}
+
+helpers.signApp = async function (adb, appPath) {
+  if (!await this.isWriteable(appPath)) {
     throw new Error(`The application at '${appPath}' is not writeable. ` +
       `Please grant write permissions to this file or to its parent folder '${path.dirname(appPath)}' ` +
       `for the Appium process, so it could sign the application`);

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -3,10 +3,11 @@ import { JWProxy } from 'appium-base-driver';
 import { waitForCondition } from 'asyncbox';
 import log from './logger';
 import { SERVER_APK_PATH as apkPath, TEST_APK_PATH as testApkPath, version as serverVersion } from 'appium-uiautomator2-server';
-import { util, logger } from 'appium-support';
+import { util, logger, tmpDir, fs } from 'appium-support';
 import B from 'bluebird';
 import helpers from './helpers';
 import request from 'request-promise';
+import path from 'path'; 
 
 const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'disableWindowAnimation'];
 const SERVER_LAUNCH_TIMEOUT = 30000;
@@ -44,61 +45,83 @@ class UiAutomator2Server {
         appId: SERVER_TEST_PACKAGE_ID,
       },
     ];
-    let shouldUninstallServerPackages = false;
-    let shouldInstallServerPackages = false;
-    for (const {appId, appPath} of packagesInfo) {
-      if (appId === SERVER_TEST_PACKAGE_ID) {
-        const isAppInstalled = await this.adb.isAppInstalled(appId);
-
-        // There is no point in getting the state for test server,
-        // since it does not contain version info
-        if (!await this.adb.checkApkCert(appPath, appId)) {
-          await helpers.signApp(this.adb, appPath);
-          shouldUninstallServerPackages = shouldUninstallServerPackages || isAppInstalled;
-          shouldInstallServerPackages = true;
-        }
-
-        if (!isAppInstalled) {
-          shouldInstallServerPackages = true;
-        }
-        continue;
+    let tmpRoot = null;
+    try {
+      const srcPackagePaths = _.map(packagesInfo, 'appPath');
+      if (_.some(await B.all(srcPackagePaths, async (x) => !await helpers.isWriteable(x)))) {
+        tmpRoot = await tmpDir.openDir();
+        log.info(`Some of the server packages at '${srcPackagePaths}' are not writeable. ` + 
+          `Will copy them into the temporary location at '${tmpRoot}' as a workaround. ` + 
+          `Consider making these files writeable in order to make UIAutomator2 session startup faster.`)
+        const [newServerPath, newServerTestPath] = await B.all(srcPackagePaths, async (srcPath) => {
+          const dstPath = path.resolve(tmpRoot, path.basename(srcPath));
+          await fs.copyFile(srcPath, dstPath);
+          return dstPath;
+        });
+        packagesInfo[0].appPath = newServerPath;
+        packagesInfo[1].appPath = newServerTestPath;
       }
+      
+      let shouldUninstallServerPackages = false;
+      let shouldInstallServerPackages = false;
+      for (const {appId, appPath} of packagesInfo) {
+        if (appId === SERVER_TEST_PACKAGE_ID) {
+          const isAppInstalled = await this.adb.isAppInstalled(appId);
 
-      const appState = await this.adb.getApplicationInstallState(appPath, appId);
-      log.debug(`${appId} installation state: ${appState}`);
-      if (await this.adb.checkApkCert(appPath, appId)) {
-        shouldUninstallServerPackages = shouldUninstallServerPackages || [
-          this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
-          this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
-        ].includes(appState);
-      } else {
-        await helpers.signApp(this.adb, appPath);
-        shouldUninstallServerPackages = shouldUninstallServerPackages || ![
+          // There is no point in getting the state for test server,
+          // since it does not contain version info
+          if (!await this.adb.checkApkCert(appPath, appId)) {
+            await helpers.signApp(this.adb, appPath);
+            shouldUninstallServerPackages = shouldUninstallServerPackages || isAppInstalled;
+            shouldInstallServerPackages = true;
+          }
+
+          if (!isAppInstalled) {
+            shouldInstallServerPackages = true;
+          }
+          continue;
+        }
+
+        const appState = await this.adb.getApplicationInstallState(appPath, appId);
+        log.debug(`${appId} installation state: ${appState}`);
+        if (await this.adb.checkApkCert(appPath, appId)) {
+          shouldUninstallServerPackages = shouldUninstallServerPackages || [
+            this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+            this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          ].includes(appState);
+        } else {
+          await helpers.signApp(this.adb, appPath);
+          shouldUninstallServerPackages = shouldUninstallServerPackages || ![
+            this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
+          ].includes(appState);
+        }
+        shouldInstallServerPackages = shouldInstallServerPackages || shouldUninstallServerPackages || [
           this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
         ].includes(appState);
       }
-      shouldInstallServerPackages = shouldInstallServerPackages || shouldUninstallServerPackages || [
-        this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
-      ].includes(appState);
-    }
-    log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
-    if (shouldInstallServerPackages && shouldUninstallServerPackages) {
-      log.info('Full packages reinstall is going to be performed');
-    }
-    for (const {appId, appPath} of packagesInfo) {
-      if (shouldUninstallServerPackages) {
-        try {
-          await this.adb.uninstallApk(appId);
-        } catch (err) {
-          log.warn(`Error uninstalling '${appId}': ${err.message}`);
+      log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
+      if (shouldInstallServerPackages && shouldUninstallServerPackages) {
+        log.info('Full packages reinstall is going to be performed');
+      }
+      for (const {appId, appPath} of packagesInfo) {
+        if (shouldUninstallServerPackages) {
+          try {
+            await this.adb.uninstallApk(appId);
+          } catch (err) {
+            log.warn(`Error uninstalling '${appId}': ${err.message}`);
+          }
+        }
+        if (shouldInstallServerPackages) {
+          await this.adb.install(appPath, {
+            replace: true,
+            timeout: installTimeout,
+            timeoutCapName: 'uiautomator2ServerInstallTimeout'
+          });
         }
       }
-      if (shouldInstallServerPackages) {
-        await this.adb.install(appPath, {
-          replace: true,
-          timeout: installTimeout,
-          timeoutCapName: 'uiautomator2ServerInstallTimeout'
-        });
+    } finally {
+      if (tmpRoot) {
+        await fs.rimraf(tmpRoot);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "appium-adb": "^7.4.0",
     "appium-android-driver": "^4.19.1",
     "appium-base-driver": "^4.0.0",
-    "appium-support": "^2.24.0",
+    "appium-support": "^2.33.0",
     "appium-uiautomator2-server": "^4.1.0",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",


### PR DESCRIPTION
This should resolve the problem with Appium Desktop where its resources are read-only by default, so Appium is unable to sign UIA2 server binaries. Yes, the session startup will be slower, because it should resign these binaries for each session init in such case, but this is better than nothing.