### PR TITLE
fix: Add locking mechanism for dynamic system port allocation algorithm

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -11,6 +11,7 @@ import uiautomator2Helpers from './helpers';
 import { androidHelpers, androidCommands, SETTINGS_HELPER_PKG_ID } from 'appium-android-driver';
 import desiredCapConstraints from './desired-caps';
 import { findAPortNotInUse } from 'portscanner';
+import AsyncLock from 'async-lock';
 
 
 const helpers = Object.assign({}, uiautomator2Helpers, androidHelpers);
@@ -18,6 +19,9 @@ const helpers = Object.assign({}, uiautomator2Helpers, androidHelpers);
 // The range of ports we can use on the system for communicating to the
 // UiAutomator2 HTTP server on the device
 const SYSTEM_PORT_RANGE = [8200, 8299];
+// The guard is needed to avoid dynamic port allocation conflicts
+// for parallel driver sessions
+const PORT_ALLOCATION_GUARD = new AsyncLock();
 
 // This is the port that UiAutomator2 listens to on the device. We will forward
 // one of the ports above on the system to this port on the device.
@@ -198,14 +202,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
         logger.info(`Neither 'app' nor 'appPackage' was set. Starting UiAutomator2 ` +
           'without the target application');
       }
-      try {
-        this.opts.systemPort = this.opts.systemPort || await findAPortNotInUse(SYSTEM_PORT_RANGE[0], SYSTEM_PORT_RANGE[1]);
-      } catch (e) {
-        logger.errorAndThrow(`Cannot find any free port in range ${_.first(SYSTEM_PORT_RANGE)}..${_.last(SYSTEM_PORT_RANGE)}}. ` +
-          `Please set the available port number by providing the systemPort capability or ` +
-          `double check the processes that are locking ports within this range and terminate ` +
-          `these which are not needed anymore`);
-      }
       this.opts.adbPort = this.opts.adbPort || DEFAULT_ADB_PORT;
 
       await this.startUiAutomator2Session();
@@ -259,6 +255,31 @@ class AndroidUiautomator2Driver extends BaseDriver {
     }
   }
 
+  async allocateSystemPort () {
+    await PORT_ALLOCATION_GUARD.acquire(AndroidUiautomator2Driver.name, async () => {
+      try {
+        this.opts.systemPort = this.opts.systemPort || await findAPortNotInUse(
+          SYSTEM_PORT_RANGE[0], SYSTEM_PORT_RANGE[1]);
+      } catch (e) {
+        logger.errorAndThrow(
+          `Cannot find any free port in range ${_.first(SYSTEM_PORT_RANGE)}..${_.last(SYSTEM_PORT_RANGE)}}. ` +
+          `Please set the available port number by providing the systemPort capability or ` +
+          `double check the processes that are locking ports within this range and terminate ` +
+          `these which are not needed anymore`);
+      }
+      logger.debug(`Forwarding UiAutomator2 Server port ${DEVICE_PORT} to ${this.opts.systemPort}`);
+      await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
+    });
+  }
+
+  async releaseSystemPort () {
+    if (!this.opts.systemPort) {
+      return;
+    }
+    await PORT_ALLOCATION_GUARD.acquire(AndroidUiautomator2Driver.name,
+      async () => await this.adb.removePortForward(this.opts.systemPort));
+  }
+
   async startUiAutomator2Session () {
     // get device udid for this session
     let {udid, emPort} = await helpers.getDeviceInfoFromCaps(this.opts);
@@ -304,12 +325,12 @@ class AndroidUiautomator2Driver extends BaseDriver {
     // TODO with multiple devices we'll need to parameterize this
     this.defaultIME = await helpers.initDevice(this.adb, this.opts);
 
+    // Prepare the device by forwarding the UiAutomator2 port
+    // This call mutates this.opts.systemPort if it is not set explicitly
+    await this.allocateSystemPort();
+
     // set up the modified UiAutomator2 server etc
     await this.initUiAutomator2Server();
-
-    // Further prepare the device by forwarding the UiAutomator2 port
-    logger.debug(`Forwarding UiAutomator2 Server port ${DEVICE_PORT} to ${this.opts.systemPort}`);
-    await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
 
     // Should be after installing io.appium.settings in helpers.initDevice
     if (this.opts.disableWindowAnimation && (await this.adb.getApiLevel() < 26)) { // API level 26 is Android 8.0.
@@ -550,14 +571,12 @@ class AndroidUiautomator2Driver extends BaseDriver {
         await this.adb.setAnimationState(true);
       }
       await this.adb.stopLogcat();
-      if (util.hasValue(this.opts.systemPort)) {
-        try {
-          await this.adb.removePortForward(this.opts.systemPort);
-        } catch (error) {
-          logger.warn(`Unable to remove port forward '${error.message}'`);
-          // Ignore, this block will also be called when we fall in catch block
-          // and before even port forward.
-        }
+      try {
+        await this.releaseSystemPort();
+      } catch (error) {
+        logger.warn(`Unable to remove port forward: ${error.message}`);
+        // Ignore, this block will also be called when we fall in catch block
+        // and before even port forward.
       }
 
       if (await this.adb.getApiLevel() >= 28) { // Android P
@@ -600,7 +619,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
   async wrapBootstrapDisconnect (wrapped) {
     await wrapped();
     await this.adb.restart();
-    await this.adb.forwardPort(this.opts.systemPort, DEVICE_PORT);
+    await this.allocateSystemPort();
   }
 
   proxyActive (sessionId) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "appium-base-driver": "^4.0.0",
     "appium-support": "^2.33.0",
     "appium-uiautomator2-server": "^4.1.0",
+    "async-lock": "^1.2.2",
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Currently I observe the situation that when two parallel sessions are executed at the same time then the `findAPortNotInUse` method returns the same available port for both sessions since none of them hasn't allocated this port yet.