### PR TITLE
Pass waitDuration to adb startApp

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -501,6 +501,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
         waitPkg: this.opts.appWaitPackage,
         waitActivity: this.opts.appWaitActivity,
         waitForLaunch: this.opts.appWaitForLaunch,
+        waitDuration: this.opts.appWaitDuration,
         optionalIntentArguments: this.opts.optionalIntentArguments,
         stopApp: !this.opts.dontStopAppOnReset,
         retry: true


### PR DESCRIPTION
## Proposed changes
Related to appium/appium#13663, seemed like uiautomator2 never passed in waitDuration to appium-adb. waitActivity always uses the default value. If i'm wrong, please ignore this PR.

## Types of changes
What types of changes does your code introduce to Appium?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules