### PR TITLE
fix: Do not require the default signature if the app under test is already signed

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -465,7 +465,10 @@ class AndroidUiautomator2Driver extends BaseDriver {
     }
 
     if (this.opts.app) {
-      if (!this.opts.noSign && !await this.adb.checkApkCert(this.opts.app, this.opts.appPackage)) {
+      if (!this.opts.noSign
+        && !await this.adb.checkApkCert(this.opts.app, this.opts.appPackage, {
+          requireDefaultCert: false,
+        })) {
         await helpers.signApp(this.adb, this.opts.app);
       }
       if (!this.opts.skipUninstall) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^7.20.0",
+    "appium-adb": "^7.24.0",
     "appium-android-driver": "^4.25.3",
     "appium-base-driver": "^5.0.0",
     "appium-support": "^2.37.0",


### PR DESCRIPTION
The signing operation takes time and could also create issues if one wants to upgrade the app under test, because it is impossible to perform reinstall if the previously installed app version has been signed with the different signature.