### PR TITLE
build: use acceleration in azure emus

### DIFF
--- a/ci-jobs/scripts/start-emulator.sh
+++ b/ci-jobs/scripts/start-emulator.sh
@@ -24,4 +24,6 @@ $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sy
 
 $ANDROID_HOME/platform-tools/adb devices
 
+sleep 30s
+
 echo "Emulator started"

--- a/ci-jobs/scripts/start-emulator.sh
+++ b/ci-jobs/scripts/start-emulator.sh
@@ -19,7 +19,7 @@ echo $ANDROID_HOME/emulator/emulator -list-avds
 echo "Starting emulator"
 
 # Start emulator in background
-nohup $ANDROID_HOME/emulator/emulator -avd testemulator -no-snapshot > /dev/null 2>&1 &
+nohup $ANDROID_HOME/emulator/emulator -avd testemulator -accel auto -nojni -no-boot-anim -no-snapshot > /dev/null 2>&1 &
 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
 
 $ANDROID_HOME/platform-tools/adb devices


### PR DESCRIPTION
Azure's MacOS environment has HAXM installed. Plus, if set to `auto` it will just ignore it if not available.