### PR TITLE
[WIP] chore: Use java8 for tests with older emulators

### DIFF
--- a/ci-jobs/pr-validation.yml
+++ b/ci-jobs/pr-validation.yml
@@ -13,11 +13,11 @@ jobs:
       name: sdk25_e2e_tests
       CHROMEDRIVER_VERSION: 2.28
       ANDROID_SDK_VERSION: 25
-      buildToolsVersion: 28.0.3
+      javaHome: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
   - template: templates/android-e2e-template.yml
     parameters:
       script: npx mocha --timeout 6000000 --reporter mocha-multi-reporters --reporter-options configFile=./ci-jobs/mochareporters.json --recursive build/test/functional/ -g @skip-ci -i --exit
       name: sdk23_e2e_tests
       CHROMEDRIVER_VERSION: 2.20
       ANDROID_SDK_VERSION: 23
-      buildToolsVersion: 28.0.3
+      javaHome: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home

--- a/ci-jobs/pr-validation.yml
+++ b/ci-jobs/pr-validation.yml
@@ -1,7 +1,4 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/android
-variables:
-  - name: JAVA_HOME
-    value: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
 jobs:
   - template: templates/android-e2e-template.yml
     parameters:
@@ -9,15 +6,18 @@ jobs:
       name: sdk28_e2e_tests
       CHROMEDRIVER_VERSION: 2.44
       ANDROID_SDK_VERSION: 28
+      javaHome: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
   - template: templates/android-e2e-template.yml
     parameters:
       script: npx mocha --timeout 6000000 --reporter mocha-multi-reporters --reporter-options configFile=./ci-jobs/mochareporters.json --recursive build/test/functional/ -g @skip-ci -i --exit
       name: sdk25_e2e_tests
       CHROMEDRIVER_VERSION: 2.28
       ANDROID_SDK_VERSION: 25
+      buildToolsVersion: 28.0.3
   - template: templates/android-e2e-template.yml
     parameters:
       script: npx mocha --timeout 6000000 --reporter mocha-multi-reporters --reporter-options configFile=./ci-jobs/mochareporters.json --recursive build/test/functional/ -g @skip-ci -i --exit
       name: sdk23_e2e_tests
       CHROMEDRIVER_VERSION: 2.20
       ANDROID_SDK_VERSION: 23
+      buildToolsVersion: 28.0.3

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -19,9 +19,9 @@ jobs:
       TERM: dumb
       MOCHA_FILE: ${{ parameters.MOCHA_FILE }}
       ANDROID_SDK_VERSION: ${{ parameters.ANDROID_SDK_VERSION }}
-      ${{ if greater(length(parameters('buildToolsVersion')), 0) }}:
+      ${{ if parameters.buildToolsVersion }}:
         BUILD_TOOLS_VERSION: ${{ parameters.buildToolsVersion }}
-      ${{ if greater(length(parameters('javaHome')), 0) }}:
+      ${{ if parameters.javaHome }}:
         JAVA_HOME: ${{ parameters.javaHome }}
     steps:
     - task: NodeTool@0

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -19,9 +19,9 @@ jobs:
       TERM: dumb
       MOCHA_FILE: ${{ parameters.MOCHA_FILE }}
       ANDROID_SDK_VERSION: ${{ parameters.ANDROID_SDK_VERSION }}
-      ${{ if length(parameters('buildToolsVersion')) > 0 }}:
+      ${{ if greater(length(parameters('buildToolsVersion')), 0) }}:
         BUILD_TOOLS_VERSION: ${{ parameters.buildToolsVersion }}
-      ${{ if length(parameters('javaHome')) > 0 }}:
+      ${{ if greater(length(parameters('javaHome')), 0) }}:
         JAVA_HOME: ${{ parameters.javaHome }}
     steps:
     - task: NodeTool@0

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -7,6 +7,8 @@ parameters:
   CHROMEDRIVER_VERSION: 2.44
   NODE_VERSION: 10.x
   ANDROID_SDK_VERSION: 28
+  buildToolsVersion: ''
+  javaHome: ''
 
 jobs:
   - job: ${{ parameters.name }}
@@ -17,6 +19,10 @@ jobs:
       TERM: dumb
       MOCHA_FILE: ${{ parameters.MOCHA_FILE }}
       ANDROID_SDK_VERSION: ${{ parameters.ANDROID_SDK_VERSION }}
+      ${{ if not(empty(parameters('buildToolsVersion'))) }}:
+        BUILD_TOOLS_VERSION: ${{ parameters.buildToolsVersion }}
+      ${{ if not(empty(parameters('javaHome'))) }}:
+        JAVA_HOME: ${{ parameters.javaHome }}
     steps:
     - task: NodeTool@0
       inputs:

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -19,9 +19,9 @@ jobs:
       TERM: dumb
       MOCHA_FILE: ${{ parameters.MOCHA_FILE }}
       ANDROID_SDK_VERSION: ${{ parameters.ANDROID_SDK_VERSION }}
-      ${{ if not(empty(parameters('buildToolsVersion'))) }}:
+      ${{ if length(parameters('buildToolsVersion')) > 0 }}:
         BUILD_TOOLS_VERSION: ${{ parameters.buildToolsVersion }}
-      ${{ if not(empty(parameters('javaHome'))) }}:
+      ${{ if length(parameters('javaHome')) > 0 }}:
         JAVA_HOME: ${{ parameters.javaHome }}
     steps:
     - task: NodeTool@0

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -14,6 +14,7 @@ const GENERIC_CAPS = {
   uiautomator2ServerInstallTimeout,
   automationName: 'uiautomator2',
   adbExecTimeout: ADB_EXEC_TIMEOUT,
+  remoteAppsCacheLimit: 0,
 };
 
 if (process.env.CLOUD) {

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -23,7 +23,9 @@ if (process.env.CLOUD) {
   GENERIC_CAPS[process.env.APPIUM_BUNDLE_CAP] = {'appium-url': 'sauce-storage:appium.zip'};
 }
 
-
+if (process.env.BUILD_TOOLS_VERSION) {
+  GENERIC_CAPS.buildToolsVersion = process.env.BUILD_TOOLS_VERSION;
+}
 
 const apiDemosApp = process.env.CLOUD
   ? 'http://appium.github.io/appium/assets/ApiDemos-debug.apk'


### PR DESCRIPTION
I have no idea why e2e started failing like https://dev.azure.com/AppiumCI/7a2a2919-d2b4-4720-a6c3-3a639f9bb2e0/_apis/build/builds/8767/logs/27 on older emulators. I'm open to any better fix proposals.