### PR TITLE
fix: Change API Policy log level from warn to info

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -321,7 +321,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
     }
 
     if (apiLevel >= 28) { // Android P
-      logger.warn('Relaxing hidden api policy');
+      logger.info('Relaxing hidden api policy');
       await this.adb.setHiddenApiPolicy('1', !!this.opts.ignoreHiddenApiPolicyError);
     }
 


### PR DESCRIPTION
Two reasons: 

1. It matches the log level further down where you reset the API Policy to the default: 

    ```js
    if (await this.adb.getApiLevel() >= 28) { // Android P
      logger.info('Restoring hidden api policy to the device default configuration');
      await this.adb.setDefaultHiddenApiPolicy();
    }
    ```

2. It's not really a warning if it's always set and not something we can actually fix/remediate.

Plus, it shows up in our console logs, which are warning only and it's noisy: 

![image](https://user-images.githubusercontent.com/180819/82927767-6cc72280-9f3e-11ea-9e28-6e72665e5489.png)


See https://github.com/appium/appium-uiautomator2-driver/pull/242#discussion_r430560813 for original discussion.