### PR TITLE
fix: Always install server binaries with incremental option disabled

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -120,6 +120,7 @@ class UiAutomator2Server {
         }
         if (shouldInstallServerPackages) {
           await this.adb.install(appPath, {
+            noIncremental: true,
             replace: true,
             timeout: installTimeout,
             timeoutCapName: 'uiautomator2ServerInstallTimeout'

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^8.0.0",
+    "appium-adb": "^8.5.0",
     "appium-android-driver": "^4.36.0",
     "appium-base-driver": "^6.2.0",
     "appium-chromedriver": "^4.23.1",


### PR DESCRIPTION
Based on https://github.com/appium/appium-adb/pull/535