### PR TITLE
feat: Expose ViewPortRect mobile command.

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -110,6 +110,7 @@ extensions.executeMobile = async function (mobileCommand, opts = {}) {
     scrollBackTo: 'mobileScrollBackTo',
     scroll: 'mobileScroll',
     viewportScreenshot: 'mobileViewportScreenshot',
+    viewportRect: 'mobileViewPortRect',
 
     deepLink: 'mobileDeepLink',
 
@@ -232,6 +233,10 @@ commands.mobileScroll = async function (opts = {}) {
 
 commands.mobileViewportScreenshot = async function () {
   return await this.getViewportScreenshot();
+};
+
+commands.mobileViewPortRect = async function () {
+  return await this.getViewPortRect();
 };
 
 commands.setUrl = async function (url) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -235,6 +235,18 @@ commands.mobileViewportScreenshot = async function () {
   return await this.getViewportScreenshot();
 };
 
+/**
+ * @typedef {object} Rectangle
+ * @property {number} left - The left coordinate of the Rectangle.
+ * @property {number} top - The top coordinate of the Rectangle.
+ * @property {number} width - The width of Rectangle.
+ * @property {number} height - The height of Rectangle.
+ */
+
+/**
+ * Returns the viewport coordinates.
+ * @returns {Rectangle} The viewport coordinates.
+ */
 commands.mobileViewPortRect = async function mobileViewPortRect () {
   return await this.getViewPortRect();
 };

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -235,7 +235,7 @@ commands.mobileViewportScreenshot = async function () {
   return await this.getViewportScreenshot();
 };
 
-commands.mobileViewPortRect = async function () {
+commands.mobileViewPortRect = async function mobileViewPortRect () {
   return await this.getViewPortRect();
 };
 


### PR DESCRIPTION
In order to be able to locate native elements correctly, one must be able to tell the viewport rectangle, in addition to getting the viewport screenshot. That's because native elements return with locations relative to the device, not the viewport.
So now, once we have a native element's coordinates, we can subtract the viewport's origin coordinate and the result will be the native element's coordinates relative to the viewport.