### PR TITLE
chore: bump basedriver dep to 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.0.0",
     "appium-adb": "^8.5.0",
     "appium-android-driver": "^4.37.0",
-    "appium-base-driver": "^6.2.0",
+    "appium-base-driver": "^7.0.0",
     "appium-chromedriver": "^4.23.1",
     "appium-support": "^2.44.0",
     "appium-uiautomator2-server": "^4.8.0",


### PR DESCRIPTION
wanting to trigger a CI run for the new basedriver