### PR TITLE
fix: Tune port guard lock options

### DIFF
--- a/ci-jobs/pr-validation.yml
+++ b/ci-jobs/pr-validation.yml
@@ -1,7 +1,3 @@
-# https://docs.microsoft.com/azure/devops/pipelines/languages/android
-variables:
-  - name: JAVA_HOME
-    value: /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
 jobs:
   #- template: templates/android-e2e-template.yml
     #parameters:

--- a/ci-jobs/templates/android-e2e-template.yml
+++ b/ci-jobs/templates/android-e2e-template.yml
@@ -30,6 +30,9 @@ jobs:
     - script: bash ci-jobs/scripts/start-emulator.sh
       displayName: Create and run Emulator
     - script: ${{ parameters.script }}
+      env:
+        JAVA_HOME: $(JAVA_HOME_11_X64)
+        PATH: $(JAVA_HOME_11_X64)/bin:$(PATH)
       displayName: Run tests
     - task: PublishTestResults@2
       condition: always()

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -24,7 +24,9 @@ const DEVICE_PORT_RANGE = [8200, 8299];
 // The guard is needed to avoid dynamic system port allocation conflicts for
 // parallel driver sessions
 const DEVICE_PORT_ALLOCATION_GUARD = util.getLockFileGuard(
-  path.resolve(os.tmpdir(), 'uia2_device_port_guard'));
+  path.resolve(os.tmpdir(), 'uia2_device_port_guard'),
+  {timeout: 25, tryRecovery: true}
+);
 
 // This is the port that UiAutomator2 listens to on the device. We will forward
 // one of the ports above on the system to this port on the device.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "appium-android-driver": "^4.37.0",
     "appium-base-driver": "^7.0.0",
     "appium-chromedriver": "^4.23.1",
-    "appium-support": "^2.44.0",
+    "appium-support": "^2.49.0",
     "appium-uiautomator2-server": "^4.8.0",
     "asyncbox": "^2.3.1",
     "axios": "^0.19.2",


### PR DESCRIPTION
If a process has been forcefully terminated then a file lock might be left in an undefined state. This PR adds an option to it, which tries to recover the lock from this state. Also, it reduces the timeout to 25 seconds, because the default adb command timeout is anyway 20 seconds.

Related to https://github.com/appium/appium/issues/14682