### PR TITLE
feat: Throw an immediate exception if instrumentation process is dead

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -208,7 +208,7 @@ class UiAutomator2Server {
       log.info(`Waiting up to ${timeout}ms for UiAutomator2 to be online...`);
       this.jwproxy.didInstrumentationExit = false;
       await this.startInstrumentationProcess();
-      if (!this.didInstrumentationExit) {
+      if (!this.jwproxy.didInstrumentationExit) {
         try {
           await waitForCondition(async () => {
             try {

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -19,14 +19,14 @@ const INSTRUMENTATION_TARGET = `${SERVER_TEST_PACKAGE_ID}/androidx.test.runner.A
 const instrumentationLogger = logger.getLogger('Instrumentation');
 
 class UIA2Proxy extends JWProxy {
-  async proxy (url, method, body = null) {
+  async proxyCommand (url, method, body = null) {
     if (this.didInstrumentationExit) {
       throw new errors.InvalidContextError(
         `'${method} ${url}' cannot be proxied to UiAutomator2 server because ` +
         'the instrumentation process is not running (probably crashed). ' +
         'Check the server log and/or the logcat output for more details');
     }
-    return await super.proxy(url, method, body);
+    return await super.proxyCommand(url, method, body);
   }
 }
 

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { JWProxy } from 'appium-base-driver';
+import { JWProxy, errors } from 'appium-base-driver';
 import { waitForCondition } from 'asyncbox';
 import log from './logger';
 import { SERVER_APK_PATH as apkPath, TEST_APK_PATH as testApkPath, version as serverVersion } from 'appium-uiautomator2-server';
@@ -18,6 +18,18 @@ const SERVER_TEST_PACKAGE_ID = `${SERVER_PACKAGE_ID}.test`;
 const INSTRUMENTATION_TARGET = `${SERVER_TEST_PACKAGE_ID}/androidx.test.runner.AndroidJUnitRunner`;
 const instrumentationLogger = logger.getLogger('Instrumentation');
 
+class UIA2Proxy extends JWProxy {
+  async proxy (url, method, body = null) {
+    if (this.didInstrumentationExit) {
+      throw new errors.InvalidContextError(
+        `'${method} ${url}' cannot be proxied to UiAutomator2 server because ` +
+        'the instrumentation process is not running (probably crashed). ' +
+        'Check the server log and/or the logcat output for more details');
+    }
+    return await super.proxy(url, method, body);
+  }
+}
+
 class UiAutomator2Server {
   constructor (opts = {}) {
     for (let req of REQD_PARAMS) {
@@ -27,12 +39,13 @@ class UiAutomator2Server {
       this[req] = opts[req];
     }
     this.disableSuppressAccessibilityService = opts.disableSuppressAccessibilityService;
-    this.jwproxy = new JWProxy({
+    this.jwproxy = new UIA2Proxy({
       server: this.host,
       port: this.systemPort,
       keepAlive: true,
     });
     this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
+    this.jwproxy.didInstrumentationExit = false;
   }
 
   /**
@@ -193,26 +206,17 @@ class UiAutomator2Server {
     const delayBetweenRetries = 3000;
     while (retries < maxRetries) {
       log.info(`Waiting up to ${timeout}ms for UiAutomator2 to be online...`);
-      let didProcessExit = false;
-      try {
-        await this.startInstrumentationProcess(() => {
-          didProcessExit = true;
-        });
-      } catch (e) {
-        didProcessExit = true;
-      }
-      if (!didProcessExit) {
+      this.jwproxy.didInstrumentationExit = false;
+      await this.startInstrumentationProcess();
+      if (!this.didInstrumentationExit) {
         try {
           await waitForCondition(async () => {
             try {
               await this.jwproxy.command('/status', 'GET');
               return true;
             } catch (err) {
-              if (didProcessExit) {
-                // short circuit to retry or fail fast
-                return true;
-              }
-              return false;
+              // short circuit to retry or fail fast
+              return this.jwproxy.didInstrumentationExit;
             }
           }, {
             waitMs: timeout,
@@ -221,10 +225,10 @@ class UiAutomator2Server {
         } catch (err) {
           log.errorAndThrow(`The instrumentation process cannot be initialized within ${timeout}ms timeout. `
             + 'Make sure the application under test does not crash and investigate the logcat output. '
-            + `You could also try to increase the value of 'uiautomator2ServerLaunchTimeout' capability. `);
+            + `You could also try to increase the value of 'uiautomator2ServerLaunchTimeout' capability`);
         }
       }
-      if (!didProcessExit) {
+      if (!this.jwproxy.didInstrumentationExit) {
         break;
       }
 
@@ -249,7 +253,7 @@ class UiAutomator2Server {
     });
   }
 
-  async startInstrumentationProcess (onExit = null) {
+  async startInstrumentationProcess () {
     const cmd = ['am', 'instrument', '-w'];
     if (this.disableWindowAnimation) {
       cmd.push('--no-window-animation');
@@ -267,11 +271,9 @@ class UiAutomator2Server {
     });
     instrumentationProcess.on('exit', (code) => {
       instrumentationLogger.debug(`The process has exited with code ${code}`);
-      if (_.isFunction(onExit)) {
-        onExit();
-      }
+      this.jwproxy.didInstrumentationExit = true;
     });
-    await instrumentationProcess.start(1000);
+    await instrumentationProcess.start(0);
   }
 
   async deleteSession () {


### PR DESCRIPTION
The previous behavior made the client to wait until timeout happens (240 seconds by default) if the server stops responding. This fix will make the code to throw an error immediately without waiting for a response and also provide more helpful exception message