### PR TITLE
fix: Make sure screen recording stops after a session is closed

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -573,8 +573,17 @@ class AndroidUiautomator2Driver extends BaseDriver {
 
   async deleteSession () {
     logger.debug('Deleting UiAutomator2 session');
+
+    try {
+      if (!_.isEmpty(this._screenRecordingProperties)) {
+        await this.stopRecordingScreen();
+      }
+    } catch (ign) {}
+
     await androidHelpers.removeAllSessionWebSocketHandlers(this.server, this.sessionId);
+
     await this.mobileStopScreenStreaming();
+
     if (this.uiautomator2) {
       try {
         await this.stopChromedriverProxies();


### PR DESCRIPTION
https://discuss.appium.io/t/the-uiautomator2-driver-keeps-recording-the-screen-even-though-the-session-has-deleted/32885