### PR TITLE
fix: Align autoLaunch capability behaviour with iOS

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -392,12 +392,10 @@ class AndroidUiautomator2Driver extends BaseDriver {
       }
     }
 
-    // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
-    if (this.opts.autoLaunch) {
-      // set up app under test
-      // prepare our actual AUT, get it on the device, etc...
-      await this.initAUT();
-    }
+    // set up app under test
+    // prepare our actual AUT, get it on the device, etc...
+    await this.initAUT();
+
     // Adding AUT package name in the capabilities if package name not exist in caps
     if (!this.caps.appPackage && appInfo) {
       this.caps.appPackage = appInfo.appPackage;


### PR DESCRIPTION
iOS does app install, but does not launch it, which makes more sense in the capability name context.