### PR TITLE
chore: Deprecate element argument in favour of elementId in `mobile: scroll` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Scrolls the given scrollable element until an element identified by `strategy` a
 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
-element | string | no | The identifier of the scrollable element. It is required this element is a valid scrollable container and it was located by `-android uiautomator` strategy. If this property is not provided then the first currently available scrollable view is selected for the interaction. | 123456-3456-3435-3453453
+elementId | string | no | The identifier of the scrollable element. It is required this element is a valid scrollable container and it was located by `-android uiautomator` strategy. If this property is not provided then the first currently available scrollable view is selected for the interaction. | 123456-3456-3435-3453453
 strategy | string | yes | The following strategies are supported: `accessibility id` (UiSelector().description), `class name` (UiSelector().className), `-android uiautomator` (UiSelector) | 'accessibility id'
 selector | string | yes | The corresponding lookup value for the selected strategy. | 'com.mycompany:id/table'
 maxSwipes | number | no | The maximum number of swipes to perform on the target scrollable view in order to reach the destination element. In case this value is unset then it would be retrieved from the scrollable element itself (vua `getMaxSearchSwipes()` property). | 10

--- a/lib/commands/gestures.js
+++ b/lib/commands/gestures.js
@@ -328,7 +328,7 @@ commands.mobileScrollBackTo = async function (opts = {}) {
 
 /**
  * @typedef {Object} ScrollOpts
- * @property {?string} element The identifier of an element. It is required this element
+ * @property {?string} elementId The identifier of an element. It is required this element
  * is a valid scrollable container and it was located by `-android uiautomator`
  * strategy. If this property is not provided then the first currently available scrollable view
  * is selected for the interaction.
@@ -356,13 +356,16 @@ commands.mobileScrollBackTo = async function (opts = {}) {
  * @throws {Error} if the scrolling operation cannot be performed
  */
 commands.mobileScroll = async function (opts = {}) {
-  const {element, strategy, selector, maxSwipes} = opts;
+  const {
+    element, elementId, // `element` is deprecated, use `elementId` instead
+    strategy, selector, maxSwipes
+  } = opts;
   if (!strategy || !selector) {
     throw new errors.InvalidArgumentError(`Both strategy and selector arguments must be provided`);
   }
   return await this.uiautomator2.jwproxy.command('/touch/scroll', 'POST', {
     params: {
-      origin: toOrigin(element),
+      origin: toOrigin(elementId || element),
       strategy, selector, maxSwipes
     },
   });


### PR DESCRIPTION
This is needed because selenium API does unexpected transformations of argument key names. See https://github.com/appium/appium/issues/15392#issuecomment-844355078 for more details