### PR TITLE
fix: Update properly name in session cleanup

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -2,8 +2,14 @@ import _ from 'lodash';
 import { JWProxy, errors } from 'appium-base-driver';
 import { waitForCondition } from 'asyncbox';
 import log from './logger';
-import { SERVER_APK_PATH as apkPath, TEST_APK_PATH as testApkPath, version as serverVersion } from 'appium-uiautomator2-server';
-import { util, logger, tempDir, fs, timing } from 'appium-support';
+import {
+  SERVER_APK_PATH as apkPath,
+  TEST_APK_PATH as testApkPath,
+  version as serverVersion
+} from 'appium-uiautomator2-server';
+import {
+  util, logger, tempDir, fs, timing
+} from 'appium-support';
 import B from 'bluebird';
 import helpers from './helpers';
 import axios from 'axios';
@@ -302,13 +308,13 @@ class UiAutomator2Server {
         url: `http://${this.host}:${this.systemPort}/wd/hub/sessions`,
         timeout: 500,
       })).data;
-      const activeSessionIds = value.map((sess) => sess.id);
+      const activeSessionIds = value.map(({sessionId}) => sessionId).filter(Boolean);
       if (activeSessionIds.length) {
         log.debug(`The following obsolete sessions are still running: ${JSON.stringify(activeSessionIds)}`);
-        log.debug('Cleaning up the obsolete sessions');
-        await B.all(activeSessionIds.map((id) =>
-          axios.delete(`http://${this.host}:${this.systemPort}/wd/hub/session/${id}`)
-        ));
+        log.debug(`Cleaning up ${util.pluralize('obsolete session', activeSessionIds.length, true)}`);
+        await B.all(activeSessionIds
+          .map((id) => axios.delete(`http://${this.host}:${this.systemPort}/wd/hub/session/${id}`))
+        );
         // Let all sessions to be properly terminated before continuing
         await B.delay(1000);
       } else {


### PR DESCRIPTION
The property name is /sessions API output is `sessionId` rather than `id`