### PR TITLE
fix: remove BASEDRIVER_HANDLED_SETTINGS since no longer exists in the base driver

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import log from '../logger';
 import B from 'bluebird';
-import { errors, BASEDRIVER_HANDLED_SETTINGS } from '@appium/base-driver';
+import { errors } from '@appium/base-driver';
 import { fs, tempDir } from '@appium/support';
 import { APK_EXTENSION } from '../extensions';
 
@@ -228,35 +228,6 @@ commands.mobileDeepLink = async function (opts = {}) {
 
 commands.openNotifications = async function () {
   return await this.uiautomator2.jwproxy.command('/appium/device/open_notifications', 'POST', {});
-};
-
-commands.updateSettings = async function (settings) {
-  // we have some settings that are set on the settings object in the driver
-  // only, for example image finding settings. The uiauto2 server does not know
-  // what to do with them, so just set them on this driver's settings instance,
-  // and don't forward them to the server
-  let driverOnlySettings = {};
-  let serverSettings = {};
-  for (let [setting, value] of _.toPairs(settings)) {
-    if (BASEDRIVER_HANDLED_SETTINGS.includes(setting)) {
-      driverOnlySettings[setting] = value;
-    } else {
-      serverSettings[setting] = value;
-    }
-  }
-  if (!_.isEmpty(driverOnlySettings)) {
-    log.info(`Found some settings designed to be handled by BaseDriver: ` +
-             `${JSON.stringify(_.keys(driverOnlySettings))}. Not ` +
-             `sending these on to the UiAutomator2 server and instead ` +
-             `setting directly on the driver`);
-    await this.settings.update(driverOnlySettings);
-  }
-  if (!_.isEmpty(serverSettings)) {
-    log.info('Forwarding the following settings to the UiAutomator2 server: ' +
-             JSON.stringify(_.keys(serverSettings)));
-    await this.uiautomator2.jwproxy.command('/appium/settings', 'POST',
-      {settings: serverSettings});
-  }
 };
 
 commands.getSettings = async function () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -713,9 +713,10 @@ class AndroidUiautomator2Driver extends BaseDriver {
     }
   }
 
-  async onSettingsUpdate () {
-    // intentionally do nothing here, since commands.updateSettings proxies
-    // settings to the uiauto2 server already
+  async onSettingsUpdate (key, value) {
+    return await this.uiautomator2.jwproxy.command('/appium/settings', 'POST',
+      {settings: {[key]: value}
+    });
   }
 
   // Need to override android-driver's version of this since we don't actually

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -715,8 +715,8 @@ class AndroidUiautomator2Driver extends BaseDriver {
 
   async onSettingsUpdate (key, value) {
     return await this.uiautomator2.jwproxy.command('/appium/settings', 'POST',
-      {settings: {[key]: value}
-    });
+      {settings: {[key]: value}}
+    );
   }
 
   // Need to override android-driver's version of this since we don't actually


### PR DESCRIPTION
I noticed the BASEDRIVER_HANDLED_SETTINGS is no longer in the base driver since the settings are in images plugin. https://github.com/appium/appium/pull/16368

So, this driver no longer needs BASEDRIVER_HANDLED_SETTINGS for now, which is driver based settings.
UIA2 driver only has plugins for the uia2 server one.

For example, test failures in https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=19412&view=results (to use appium 2.0 as its test) failed by this undefined BASEDRIVER_HANDLED_SETTINGS