### PR TITLE
fix: Read package name from web view info if not provided explicitly by updating android driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@appium/support": "^2.55.3",
     "@babel/runtime": "^7.0.0",
     "appium-adb": "^9.0.0",
-    "appium-android-driver": "^5.0.0",
+    "appium-android-driver": "^5.0.6",
     "appium-chromedriver": "^5.0.1",
     "appium-uiautomator2-server": "^5.3.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
So far, our each driver release includes `shrinkwrap` to specify dependencies.
https://github.com/appium/appium-uiautomator2-driver/blob/master/.github/workflows/publish.js.yml

It needs to push a new version when we'd like to include dependencies's update like https://github.com/appium/appium-android-driver/pull/732
(This PR change itself does not need, but it needs to kick a release task)