### PR TITLE
fix: wrong parameter in performActions

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -27,7 +27,7 @@ commands.performActions = async function (actions) {
       }
     } : {}));
   this.log.debug(`Preprocessed actions: ${JSON.stringify(preprocessedActions, null, '  ')}`);
-  return await this.uiautomator2.jwproxy.command('/actions', 'POST', {preprocessedActions});
+  return await this.uiautomator2.jwproxy.command('/actions', 'POST', {actions: preprocessedActions});
 };
 
 Object.assign(extensions, commands);

--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -27,7 +27,7 @@ commands.performActions = async function (actions) {
       }
     } : {}));
   this.log.debug(`Preprocessed actions: ${JSON.stringify(preprocessedActions, null, '  ')}`);
-  return await this.uiautomator2.jwproxy.command('/actions', 'POST', {actions});
+  return await this.uiautomator2.jwproxy.command('/actions', 'POST', {preprocessedActions});
 };
 
 Object.assign(extensions, commands);


### PR DESCRIPTION
ActionChains in selenium have a PointerInput whose kind(pointerType) is "mouse".
We should change this to "touch" for android devices to work properly.
(I confired "mouse" doesn't work and "touch" works.)
There is code for converting "mouse" to "touch" ("preprocessedActions")
But wrong old variable was used.