### PR TITLE
feat: activateApp calls "am start" for over api level 24 devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,9 @@ UiAutomator2 driver supports Appium endpoints for applications management:
 - Check if app is installed (`POST /appium/device/app_installed`)
 - Install/upgrade app (`POST /appium/device/install_app`)
 - Active app (`POST /appium/device/activate_app`)
-    - The backend calls [monkey](https://developer.android.com/studio/test/other-testing-tools/monkey) command. It [turns on auto rotation](https://stackoverflow.com/questions/56684778/adb-shell-monkey-command-changing-device-orientation-lock), so please consider to use [mobile: startActivity](#mobile-startactivity) if you would like to keep the rotation preference.
+    - Since UIAutomator2 driver v2.2.0, this backend calls `am start`/`am start-activity` command to start the application for over API Level 24 devices. IT still calls [monkey](https://developer.android.com/studio/test/other-testing-tools/monkey) command for lower than API Level 24 devices.
+    - Before the version calls the monkey command.
+    - The monkey command [turns on auto rotation](https://stackoverflow.com/questions/56684778/adb-shell-monkey-command-changing-device-orientation-lock), so please consider to use [mobile: startActivity](#mobile-startactivity) if you would like to keep the rotation preference.
 - Uninstall app (`POST /appium/device/remove_app`)
 - Terminate app (`POST /appium/device/terminate_app`)
 - Start app activity (`POST /appium/device/start_activity`)

--- a/README.md
+++ b/README.md
@@ -798,8 +798,8 @@ UiAutomator2 driver supports Appium endpoints for applications management:
 - Check if app is installed (`POST /appium/device/app_installed`)
 - Install/upgrade app (`POST /appium/device/install_app`)
 - Active app (`POST /appium/device/activate_app`)
-    - Since UIAutomator2 driver v2.2.0, this backend calls `am start`/`am start-activity` command to start the application for over API Level 24 devices. IT still calls [monkey](https://developer.android.com/studio/test/other-testing-tools/monkey) command for lower than API Level 24 devices.
-    - Before the version calls the monkey command.
+    - Since UIAutomator2 driver v2.2.0, this backend calls `am start`/`am start-activity` command to start the application for over API Level 24 devices. It calls [monkey](https://developer.android.com/studio/test/other-testing-tools/monkey) command for devices that are lower than API Level 24.
+    - UIAutomator2 driver v2.1.2 and lower versions call the `monkey` command for all devices.
     - The monkey command [turns on auto rotation](https://stackoverflow.com/questions/56684778/adb-shell-monkey-command-changing-device-orientation-lock), so please consider to use [mobile: startActivity](#mobile-startactivity) if you would like to keep the rotation preference.
 - Uninstall app (`POST /appium/device/remove_app`)
 - Terminate app (`POST /appium/device/terminate_app`)

--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ UiAutomator2 driver supports Appium endpoints for applications management:
 - Check if app is installed (`POST /appium/device/app_installed`)
 - Install/upgrade app (`POST /appium/device/install_app`)
 - Active app (`POST /appium/device/activate_app`)
-    - Since UIAutomator2 driver v2.2.0, this backend calls `am start`/`am start-activity` command to start the application for over API Level 24 devices. It calls [monkey](https://developer.android.com/studio/test/other-testing-tools/monkey) command for devices that are lower than API Level 24.
+    - Since UIAutomator2 driver v2.2.0, the backend calls `am start`/`am start-activity` to start the application for over API Level 24 devices. It calls [monkey](https://developer.android.com/studio/test/other-testing-tools/monkey) command for devices that are lower than API Level 24.
     - UIAutomator2 driver v2.1.2 and lower versions call the `monkey` command for all devices.
     - The monkey command [turns on auto rotation](https://stackoverflow.com/questions/56684778/adb-shell-monkey-command-changing-device-orientation-lock), so please consider to use [mobile: startActivity](#mobile-startactivity) if you would like to keep the rotation preference.
 - Uninstall app (`POST /appium/device/remove_app`)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@appium/support": "^2.55.3",
     "@babel/runtime": "^7.0.0",
     "appium-adb": "^9.0.0",
-    "appium-android-driver": "^5.0.9",
+    "appium-android-driver": "^5.0.14",
     "appium-chromedriver": "^5.0.2",
     "appium-uiautomator2-server": "^5.6.0",
     "asyncbox": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@appium/support": "^2.55.3",
     "@babel/runtime": "^7.0.0",
     "appium-adb": "^9.0.0",
-    "appium-android-driver": "^5.0.14",
+    "appium-android-driver": "^5.0.15",
     "appium-chromedriver": "^5.0.2",
     "appium-uiautomator2-server": "^5.6.0",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
Maybe it would be nice to bump the minor version up since activateApp behaves a bit differently for API level 24.