### PR TITLE
test: calls createSession before accessing `opts` in the driver instance

### DIFF
--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -16,9 +16,24 @@ function defaultStub (driver) {
 
 describe('driver.js', function () {
   describe('constructor', function () {
-    it('calls BaseDriver constructor with opts', function () {
+    it('calls BaseDriver constructor with opts', async function () {
       let driver = new AndroidUiautomator2Driver({foo: 'bar'});
       driver.should.exist;
+      defaultStub(driver);
+      sinon.mock(driver).expects('checkAppPresent')
+          .once()
+          .returns(B.resolve());
+      sinon.mock(driver).expects('startUiAutomator2Session')
+          .once()
+          .returns(B.resolve());
+      await driver.createSession(null, null, {
+        firstMatch: [{}],
+        alwaysMatch: {
+          platformName: 'Android',
+          'appium:deviceName': 'device',
+          browserName: 'chrome',
+        }
+      });
       driver.opts.foo.should.equal('bar');
     });
   });
@@ -140,7 +155,23 @@ describe('driver.js', function () {
       it('should exist', function () {
         driver.getProxyAvoidList.should.be.an.instanceof(Function);
       });
-      it('should return jwpProxyAvoid array', function () {
+      it('should return jwpProxyAvoid array', async function () {
+        driver = new AndroidUiautomator2Driver({}, false);
+        defaultStub(driver);
+        sinon.mock(driver).expects('checkAppPresent')
+            .once()
+            .returns(B.resolve());
+        sinon.mock(driver).expects('startUiAutomator2Session')
+            .once()
+            .returns(B.resolve());
+        await driver.createSession(null, null, {
+          firstMatch: [{}],
+          alwaysMatch: {
+            platformName: 'Android',
+            'appium:deviceName': 'device',
+            browserName: 'chrome',
+          }
+        });
         let avoidList = driver.getProxyAvoidList('abc');
         avoidList.should.be.an.instanceof(Array);
         avoidList.should.eql(driver.jwpProxyAvoid);
@@ -150,6 +181,7 @@ describe('driver.js', function () {
           driver.getProxyAvoidList('aaa');
         }).should.throw;
       });
+
       describe('nativeWebScreenshot', function () {
         let proxyAvoidList;
         let nativeWebScreenshotFilter = (item) => item[0] === 'GET' && item[1].test('/session/xxx/screenshot/');
@@ -273,11 +305,27 @@ describe('driver.js', function () {
 
   describe('deleteSession', function () {
     let driver;
-    beforeEach(function () {
+    beforeEach(async function () {
       driver = new AndroidUiautomator2Driver({}, false);
       driver.adb = new ADB();
       driver.caps = {};
       sandbox.stub(driver.adb, 'stopLogcat');
+
+      defaultStub(driver);
+      sinon.mock(driver).expects('checkAppPresent')
+          .once()
+          .returns(B.resolve());
+      sinon.mock(driver).expects('startUiAutomator2Session')
+          .once()
+          .returns(B.resolve());
+      await driver.createSession(null, null, {
+        firstMatch: [{}],
+        alwaysMatch: {
+          platformName: 'Android',
+          'appium:deviceName': 'device',
+          browserName: 'chrome'
+        }
+      });
     });
     afterEach(function () {
       sandbox.restore();


### PR DESCRIPTION
Context: https://github.com/appium/appium-uiautomator2-driver/pull/554#issuecomment-1278581519

I wonder if we must update all test code to access opts after createSession call, or something like adding `driver.opts = {}`, or this is an unexpected change in the core. Maybe related to https://github.com/appium/appium/pull/17559

I separated PR from https://github.com/appium/appium-uiautomator2-driver/pull/554
cc @mykola-mokhnach @boneskull 