### PR TITLE
chore: bump UIA2 server to use non-android.permission.WRITE_EXTERNAL_STORAGE one

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "appium-adb": "^9.10.14",
     "appium-android-driver": "^5.7.0",
     "appium-chromedriver": "^5.2.1",
-    "appium-uiautomator2-server": "^5.7.0",
+    "appium-uiautomator2-server": "^5.7.2",
     "asyncbox": "^2.3.1",
     "axios": "^1.x",
     "bluebird": "^3.5.1",


### PR DESCRIPTION
Closes https://github.com/appium/appium/issues/17679