### PR TITLE
fix: specify supported non-standard commands in newMethodMap

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -3,15 +3,14 @@ import { BaseDriver, DeviceSettings } from 'appium/driver';
 import {
   UiAutomator2Server, SERVER_PACKAGE_ID, SERVER_TEST_PACKAGE_ID
 } from './uiautomator2';
+import { newMethodMap } from './method-map';
 import { fs, util, mjpeg } from 'appium/support';
 import { retryInterval } from 'asyncbox';
 import B from 'bluebird';
 import commands from './commands/index';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
 import uiautomator2Helpers from './helpers';
-import {
-  androidHelpers, androidCommands, SETTINGS_HELPER_PKG_ID
-} from 'appium-android-driver';
+import { androidHelpers, androidCommands, SETTINGS_HELPER_PKG_ID, } from 'appium-android-driver';
 import desiredCapConstraints from './desired-caps';
 import { findAPortNotInUse, checkPortStatus } from 'portscanner';
 import os from 'os';
@@ -145,6 +144,9 @@ const MEMOIZED_FUNCTIONS = [
 ];
 
 class AndroidUiautomator2Driver extends BaseDriver {
+
+  static newMethodMap = newMethodMap;
+
   constructor (opts = {}, shouldValidateCaps = true) {
     // `shell` overwrites adb.shell, so remove
     delete opts.shell;

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -1,0 +1,11 @@
+import { AndroidDriver } from 'appium-android-driver';
+
+export const newMethodMap = /** @type {const} */ ({
+  ...AndroidDriver.newMethodMap,
+  '/session/:sessionId/appium/device/get_clipboard': {
+    POST: {
+      command: 'getClipboard',
+      payloadParams: { optional: ['contentType'] }
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-adb": "^9.10.14",
-    "appium-android-driver": "^5.8.5",
+    "appium-android-driver": "^5.8.7",
     "appium-chromedriver": "^5.2.1",
     "appium-uiautomator2-server": "^5.7.2",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
depends on https://github.com/appium/appium-android-driver/pull/782