### PR TITLE
ci: fix and enable some commands e2e specs

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -68,6 +68,15 @@ jobs:
         api-level: ${{ matrix.apiLevel }}
         disable-spellchecker: true
         target: ${{ matrix.emuTag }}
+    - uses: reactivecircus/android-emulator-runner@v2
+      name: e2e_api${{ matrix.apiLevel }}
+      with:
+        script: npm run e2e-test:commands
+        avd-name: ${{ env.ANDROID_AVD }}
+        sdcard-path-or-size: 1500M
+        api-level: ${{ matrix.apiLevel }}
+        disable-spellchecker: true
+        target: ${{ matrix.emuTag }}
     - name: Save logcat output
       if: ${{ always() }}
       uses: actions/upload-artifact@master

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -6,6 +6,7 @@ on: [pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         include:
         - chromedriverVersion: "74.0.3729.6"

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -54,6 +54,8 @@ jobs:
           --port=$APPIUM_TEST_SERVER_PORT \
           --address=$APPIUM_TEST_SERVER_HOST \
           --relaxed-security \
+          --log-no-colors \
+          --log-timestamp \
           2>&1 > "$cwd/appium.log" &
         popd
       name: Start Appium server
@@ -62,16 +64,9 @@ jobs:
     - uses: reactivecircus/android-emulator-runner@v2
       name: e2e_api${{ matrix.apiLevel }}
       with:
-        script: npm run e2e-test:driver
-        avd-name: ${{ env.ANDROID_AVD }}
-        sdcard-path-or-size: 1500M
-        api-level: ${{ matrix.apiLevel }}
-        disable-spellchecker: true
-        target: ${{ matrix.emuTag }}
-    - uses: reactivecircus/android-emulator-runner@v2
-      name: e2e_api${{ matrix.apiLevel }}
-      with:
-        script: npm run e2e-test:commands
+        script: |
+          npm run e2e-test:driver
+          npm run e2e-test:commands
         avd-name: ${{ env.ANDROID_AVD }}
         sdcard-path-or-size: 1500M
         api-level: ${{ matrix.apiLevel }}

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "precommit-lint": "lint-staged",
     "prepare": "npm run build",
     "test": "mocha --exit --timeout 1m \"./test/unit/**/*-specs.js\"",
-    "e2e-test:driver": "mocha --exit --timeout 10m \"./test/functional/driver-e2e-specs.js\""
+    "e2e-test:driver": "mocha --exit --timeout 10m \"./test/functional/driver-e2e-specs.js\"",
+    "e2e-test:commands": "mocha --exit --timeout 10m \"./test/functional/commands\""
   },
   "pre-commit": [
     "precommit-msg",

--- a/test/functional/commands/file-movement-e2e-specs.js
+++ b/test/functional/commands/file-movement-e2e-specs.js
@@ -58,7 +58,9 @@ describe('file movement', function () {
       zipStream
         .pipe(unzipper.Parse())
         .on('entry', function (entry) {
-          entryCount++;
+          if (entry.type === 'File') {
+            entryCount++;
+          }
           entry.autodrain();
         })
         .on('close', function () {

--- a/test/functional/commands/geo-location-e2e-specs.js
+++ b/test/functional/commands/geo-location-e2e-specs.js
@@ -48,10 +48,6 @@ describe('geo-location -', function () {
     const latitude = getRandomInt(-90, 90);
     const longitude = getRandomInt(-180, 180);
 
-    let text = await getText();
-    text.should.not.include(`Latitude: ${latitude}`);
-    text.should.not.include(`Longitude: ${longitude}`);
-
     await driver.setGeoLocation({latitude, longitude});
 
     // wait for the text to change
@@ -62,7 +58,7 @@ describe('geo-location -', function () {
     });
 
     await retryInterval(30, 1000, async function () {
-      text = await getText();
+      const text = await getText();
       text.should.include(`Latitude: ${latitude}`);
       text.should.include(`Longitude: ${longitude}`);
     });

--- a/test/functional/commands/geo-location-e2e-specs.js
+++ b/test/functional/commands/geo-location-e2e-specs.js
@@ -24,14 +24,14 @@ describe('geo-location -', function () {
 
   it('should set geo location', async function () {
     // If we hit the permission screen, click the 'Continue Button' (sdk >= 28)
-    const continueButtons = await driver.elementsById('com.android.permissioncontroller:id/continue_button');
+    const continueButtons = await driver.$$('id:com.android.permissioncontroller:id/continue_button');
     if (continueButtons.length > 0) {
       await continueButtons[0].click();
     }
 
     // Get rid of the modal window saying that the app was built for an old version
     await B.delay(1000);
-    const okButtons = await driver.elementsById('android:id/button1');
+    const okButtons = await driver.$$('id:android:id/button1');
     if (okButtons.length > 0) {
       await okButtons[0].click();
     }
@@ -39,9 +39,9 @@ describe('geo-location -', function () {
     // Get the text in the app that tells us the latitude and logitude
     const getText = async function () {
       return await retryInterval(10, 1000, async function () {
-        const textViews = await driver.elementsByClassName('android.widget.TextView');
+        const textViews = await driver.$$('android.widget.TextView');
         textViews.length.should.be.at.least(2);
-        return await textViews[1].text();
+        return await textViews[1].getText();
       });
     };
 
@@ -52,7 +52,7 @@ describe('geo-location -', function () {
     text.should.not.include(`Latitude: ${latitude}`);
     text.should.not.include(`Longitude: ${longitude}`);
 
-    await driver.setGeoLocation(latitude, longitude);
+    await driver.setGeoLocation({latitude, longitude});
 
     // wait for the text to change
     await retryInterval(10, 1000, async () => {
@@ -66,5 +66,9 @@ describe('geo-location -', function () {
       text.should.include(`Latitude: ${latitude}`);
       text.should.include(`Longitude: ${longitude}`);
     });
+
+    const loc = await driver.getGeoLocation();
+    loc.latitude.should.equal(latitude);
+    loc.longitude.should.equal(longitude);
   });
 });

--- a/test/functional/commands/language-e2e-specs.js
+++ b/test/functional/commands/language-e2e-specs.js
@@ -16,10 +16,6 @@ describe('Localization - locale @skip-ci @skip-real-device', function () {
   let adb;
 
   before(async function () {
-    if (process.env.TESTOBJECT_E2E_TESTS) {
-      this.skip();
-    }
-
     // restarting doesn't work on Android 7+
     adb = new ADB();
 

--- a/test/functional/commands/language-e2e-specs.js
+++ b/test/functional/commands/language-e2e-specs.js
@@ -18,6 +18,7 @@ describe('Localization - locale @skip-ci @skip-real-device', function () {
   before(async function () {
     // restarting doesn't work on Android 7+
     adb = new ADB();
+    if (await adb.getApiLevel() <= 23) return this.skip(); //eslint-disable-line curly
 
     initialLocale = await getLocale(adb);
   });
@@ -25,12 +26,8 @@ describe('Localization - locale @skip-ci @skip-real-device', function () {
   let driver;
   after(async function () {
     if (driver) {
-      if (await adb.getApiLevel() > 23) {
-        let [language, country] = initialLocale.split('-');
-        await androidHelpers.ensureDeviceLocale(adb, language, country);
-      } else {
-        await androidHelpers.ensureDeviceLocale(adb, null, initialLocale);
-      }
+      let [language, country] = initialLocale.split('-');
+      await androidHelpers.ensureDeviceLocale(adb, language, country);
       await deleteSession();
     }
   });

--- a/test/functional/commands/language-e2e-specs.js
+++ b/test/functional/commands/language-e2e-specs.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import ADB from 'appium-adb';
 import { initSession, deleteSession } from '../helpers/session';
-import { APIDEMOS_CAPS } from '../desired';
+import { APIDEMOS_CAPS, amendCapabilities } from '../desired';
 import { androidHelpers } from 'appium-android-driver';
 import { getLocale } from '../helpers/helpers';
 
@@ -21,8 +21,7 @@ describe('Localization - locale @skip-ci @skip-real-device', function () {
     }
 
     // restarting doesn't work on Android 7+
-    let adb = new ADB();
-    if (await adb.getApiLevel() > 23) return this.skip(); //eslint-disable-line curly
+    adb = new ADB();
 
     initialLocale = await getLocale(adb);
   });
@@ -32,26 +31,26 @@ describe('Localization - locale @skip-ci @skip-real-device', function () {
     if (driver) {
       if (await adb.getApiLevel() > 23) {
         let [language, country] = initialLocale.split('-');
-        await androidHelpers.ensureDeviceLocale(driver.adb, language, country);
+        await androidHelpers.ensureDeviceLocale(adb, language, country);
       } else {
-        await androidHelpers.ensureDeviceLocale(driver.adb, null, initialLocale);
+        await androidHelpers.ensureDeviceLocale(adb, null, initialLocale);
       }
       await deleteSession();
     }
   });
 
   it('should start as FR', async function () {
-    let frCaps = Object.assign({}, APIDEMOS_CAPS, {
-      language: 'fr',
-      locale: 'FR',
+    let frCaps = amendCapabilities(APIDEMOS_CAPS, {
+      'appium:language': 'fr',
+      'appium:locale': 'FR',
     });
-    driver = await initSession(frCaps);
+    const driver = await initSession(frCaps);
     await getLocale(driver.adb).should.eventually.equal('fr-FR');
   });
   it('should start as US', async function () {
-    let usCaps = Object.assign({}, APIDEMOS_CAPS, {
-      language: 'en',
-      locale: 'US',
+    let usCaps = amendCapabilities(APIDEMOS_CAPS, {
+      'appium:language': 'en',
+      'appium:locale': 'US',
     });
     driver = await initSession(usCaps);
     await getLocale(driver.adb).should.eventually.equal('en-US');

--- a/test/functional/commands/orientation-e2e-specs.js
+++ b/test/functional/commands/orientation-e2e-specs.js
@@ -53,7 +53,7 @@ describe('apidemo - orientation -', function () {
       await B.delay(3000);
       await driver.getOrientation().should.eventually.become('LANDSCAPE');
     });
-    it('should rotate screen to landscape', async function () {
+    it('should rotate screen to portrait', async function () {
       await driver.setOrientation('LANDSCAPE');
       await B.delay(3000);
       await driver.setOrientation('PORTRAIT');

--- a/test/functional/commands/orientation-e2e-specs.js
+++ b/test/functional/commands/orientation-e2e-specs.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
-import { APIDEMOS_CAPS } from '../desired';
+import { APIDEMOS_CAPS, amendCapabilities } from '../desired';
 import { initSession, deleteSession } from '../helpers/session';
 
 
@@ -17,30 +17,30 @@ describe('apidemo - orientation -', function () {
       await deleteSession();
     });
     it('should have portrait orientation if requested', async function () {
-      driver = await initSession(Object.assign({}, APIDEMOS_CAPS, {
-        appActivity: '.view.TextFields',
-        orientation: 'PORTRAIT',
+      driver = await initSession(amendCapabilities(APIDEMOS_CAPS, {
+        'appium:appActivity': '.view.TextFields',
+        'appium:orientation': 'PORTRAIT',
       }));
       await driver.getOrientation().should.eventually.eql('PORTRAIT');
     });
     it('should have landscape orientation if requested', async function () {
-      driver = await initSession(Object.assign({}, APIDEMOS_CAPS, {
-        appActivity: '.view.TextFields',
-        orientation: 'LANDSCAPE',
+      driver = await initSession(amendCapabilities(APIDEMOS_CAPS, {
+        'appium:appActivity': '.view.TextFields',
+        'appium:orientation': 'LANDSCAPE',
       }));
       await driver.getOrientation().should.eventually.eql('LANDSCAPE');
     });
     it('should have portrait orientation if nothing requested', async function () {
-      driver = await initSession(Object.assign({}, APIDEMOS_CAPS, {
-        appActivity: '.view.TextFields',
+      driver = await initSession(amendCapabilities(APIDEMOS_CAPS, {
+        'appium:appActivity': '.view.TextFields',
       }));
       await driver.getOrientation().should.eventually.eql('PORTRAIT');
     });
   });
   describe('setting -', function () {
     before(async function () {
-      driver = await initSession(Object.assign({}, APIDEMOS_CAPS, {
-        appActivity: '.view.TextFields'
+      driver = await initSession(amendCapabilities(APIDEMOS_CAPS, {
+        'appium:appActivity': '.view.TextFields'
       }));
     });
     after(async function () {

--- a/test/functional/commands/strings-e2e-specs.js
+++ b/test/functional/commands/strings-e2e-specs.js
@@ -15,17 +15,10 @@ describe('strings', function () {
 
   describe('specific language', function () {
     before(async function () {
-      // Don't run these tests on TestObject. On TO, we don't have access to the .apk
-      // which is necessary for extracting the app strings
-      if (process.env.TESTOBJECT_E2E_TESTS) {
-        this.skip();
-      }
       driver = await initSession(APIDEMOS_CAPS);
     });
     after(async function () {
-      if (!process.env.TESTOBJECT_E2E_TESTS) {
-        await deleteSession();
-      }
+      await deleteSession();
     });
 
     it('should return app strings', async function () {
@@ -43,10 +36,6 @@ describe('strings', function () {
     let initialLocale;
     let adb;
     before(async function () {
-      // Don't test ADB on test object
-      if (process.env.TESTOBJECT_E2E_TESTS) {
-        this.skip();
-      }
       // restarting doesn't work on Android 7+
       adb = new ADB();
       initialLocale = await getLocale(adb);
@@ -74,9 +63,6 @@ describe('strings', function () {
       strings.hello_world.should.equal('Hello, World!');
     });
     it('should return app strings when language/locale set @skip-ci', async function () {
-      if (process.env.TESTOBJECT_E2E_TESTS) {
-        this.skip();
-      }
       const caps = amendCapabilities(APIDEMOS_CAPS, {
         'appium:language': 'fr',
         'appium:locale': 'CA',

--- a/test/functional/commands/strings-e2e-specs.js
+++ b/test/functional/commands/strings-e2e-specs.js
@@ -1,10 +1,9 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { APIDEMOS_CAPS } from '../desired';
+import { APIDEMOS_CAPS, amendCapabilities } from '../desired';
 import ADB from 'appium-adb';
 import { initSession, deleteSession } from '../helpers/session';
 import { getLocale } from '../helpers/helpers';
-import _ from 'lodash';
 import { androidHelpers } from 'appium-android-driver';
 
 
@@ -30,12 +29,12 @@ describe('strings', function () {
     });
 
     it('should return app strings', async function () {
-      let strings = await driver.getAppStrings('en');
+      let strings = await driver.getStrings('en');
       strings.hello_world.should.equal('Hello, World!');
     });
 
     it('should return app strings for different language', async function () {
-      let strings = await driver.getAppStrings('fr');
+      let strings = await driver.getStrings('fr');
       strings.hello_world.should.equal('Bonjour, Monde!');
     });
   });
@@ -71,19 +70,20 @@ describe('strings', function () {
     it('should return app strings with default locale/language', async function () {
       driver = await initSession(APIDEMOS_CAPS);
 
-      let strings = await driver.getAppStrings();
+      let strings = await driver.getStrings();
       strings.hello_world.should.equal('Hello, World!');
     });
     it('should return app strings when language/locale set @skip-ci', async function () {
       if (process.env.TESTOBJECT_E2E_TESTS) {
         this.skip();
       }
-      driver = await initSession(_.defaults({
-        language: 'fr',
-        locale: 'CA',
-      }, APIDEMOS_CAPS));
+      const caps = amendCapabilities(APIDEMOS_CAPS, {
+        'appium:language': 'fr',
+        'appium:locale': 'CA',
+      });
+      const driver = await initSession(caps);
 
-      let strings = await driver.getAppStrings();
+      let strings = await driver.getStrings();
       strings.hello_world.should.equal('Bonjour, Monde!');
     });
   });

--- a/test/functional/commands/viewport-e2e-specs.js
+++ b/test/functional/commands/viewport-e2e-specs.js
@@ -21,7 +21,7 @@ describe('testViewportCommands', function () {
   });
 
   it('should get device pixel ratio, status bar height, and viewport rect', async function () {
-    const {viewportRect, statBarHeight, pixelRatio} = await driver.sessionCapabilities();
+    const {viewportRect, statBarHeight, pixelRatio} = await driver.getSession();
     pixelRatio.should.exist;
     pixelRatio.should.not.equal(0);
     statBarHeight.should.exist;
@@ -34,27 +34,27 @@ describe('testViewportCommands', function () {
   });
 
   it('should get scrollable element', async function () {
-    let scrollableEl = await driver.elementByXPath('//*[@scrollable="true"]');
+    let scrollableEl = await driver.$('//*[@scrollable="true"]');
     scrollableEl.should.exist;
   });
 
   it('should get content size from scrollable element found as uiobject', async function () {
-    let scrollableEl = await driver.elementByXPath('//*[@scrollable="true"]');
+    let scrollableEl = await driver.$('//*[@scrollable="true"]');
     let contentSize = await scrollableEl.getAttribute('contentSize');
     contentSize.should.exist;
     JSON.parse(contentSize).scrollableOffset.should.exist;
   });
 
   it('should get content size from scrollable element found as uiobject2', async function () {
-    let scrollableEl = await driver.elementByXPath('//android.widget.ScrollView');
+    let scrollableEl = await driver.$('//android.widget.ScrollView');
     let contentSize = await scrollableEl.getAttribute('contentSize');
     contentSize.should.exist;
     JSON.parse(contentSize).scrollableOffset.should.exist;
   });
 
   it('should get first element from scrollable element', async function () {
-    let scrollableEl = await driver.elementByXPath('//*[@scrollable="true"]');
-    let element = await scrollableEl.elementByXPath('/*[@firstVisible="true"]');
+    let scrollableEl = await driver.$('//*[@scrollable="true"]');
+    let element = await scrollableEl.$('/*[@firstVisible="true"]');
     element.should.exist;
   });
 
@@ -63,7 +63,7 @@ describe('testViewportCommands', function () {
     if (process.env.CI) {
       return this.skip();
     }
-    const {viewportRect, statBarHeight} = await driver.sessionCapabilities();
+    const {viewportRect, statBarHeight} = await driver.getSession();
     const fullScreen = await driver.takeScreenshot();
     const viewScreen = await driver.execute('mobile: viewportScreenshot');
     const fullB64 = Buffer.from(fullScreen, 'base64');


### PR DESCRIPTION
I just started looking into https://github.com/appium/appium/issues/16402
This PR aims for spec files directly under `test/functional/commands` dir. Subdirectories are not included.
I confirmed `npm run e2e-test:commands` passed on my laptop with `android-30;google_apis;arm64-v8a` emulator.

I have a question, what is `process.env.TESTOBJECT_E2E_TESTS` for? Do you still use it?