### PR TITLE
chore: remove unused unicodeKeyboard as uia2

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -68,8 +68,7 @@ commands.setValueImmediate = async function (keys, elementId) {
   return await this.uiautomator2.jwproxy.command(`/element/${elementId}/value`, 'POST', {
     elementId,
     text: _.isArray(keys) ? keys.join('') : keys,
-    replace: false,
-    unicodeKeyboard: this.opts.unicodeKeyboard,
+    replace: false
   });
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -163,7 +163,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
     this.desiredCapConstraints = desiredCapConstraints;
     this.uiautomator2 = null;
     this.jwpProxyActive = false;
-    this.defaultIME = null;
     this.jwpProxyAvoid = NO_PROXY;
     this.apkStrings = {}; // map of language -> strings obj
 
@@ -388,7 +387,7 @@ class AndroidUiautomator2Driver extends BaseDriver {
 
     // start an avd, set the language/locale, pick an emulator, etc...
     // TODO with multiple devices we'll need to parameterize this
-    this.defaultIME = await helpers.initDevice(this.adb, this.opts);
+    await helpers.initDevice(this.adb, this.opts);
 
     // Prepare the device by forwarding the UiAutomator2 port
     // This call mutates this.opts.systemPort if it is not set explicitly
@@ -647,14 +646,6 @@ class AndroidUiautomator2Driver extends BaseDriver {
         })();
       }));
 
-      if (this.opts.unicodeKeyboard && this.opts.resetKeyboard && this.defaultIME) {
-        this.log.debug(`Resetting IME to '${this.defaultIME}'`);
-        try {
-          await this.adb.setIME(this.defaultIME);
-        } catch (err) {
-          this.log.warn(`Unable to reset IME: ${err.message}`);
-        }
-      }
       if (this.caps.androidCoverage) {
         this.log.info('Shutting down the adb process of instrumentation...');
         await this.adb.endAndroidCoverage();

--- a/test/functional/commands/general/ime-e2e-specs.js
+++ b/test/functional/commands/general/ime-e2e-specs.js
@@ -12,7 +12,7 @@ const unicodeImeId = 'io.appium.settings/.UnicodeIME';
 describe('apidemo - IME', function () {
   let driver;
   before(async function () {
-    driver = await initSession(Object.assign({}, APIDEMOS_CAPS, {unicodeKeyboard: true, resetKeyboard: true}));
+    driver = await initSession(Object.assign(APIDEMOS_CAPS));
   });
   beforeEach(async function () {
     await driver.startActivity({appPackage: 'io.appium.android.apis', appActivity: 'io.appium.android.apis.ApiDemos'});

--- a/test/functional/commands/keyboard/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard/keyboard-e2e-specs.js
@@ -24,10 +24,7 @@ const defaultAsciiCaps = Object.assign({}, APIDEMOS_CAPS, {
   appActivity: TEXTFIELD_ACTIVITY
 });
 
-const defaultUnicodeCaps = Object.assign({}, defaultAsciiCaps, {
-  unicodeKeyboard: true,
-  resetKeyboard: true
-});
+const defaultUnicodeCaps = defaultAsciiCaps;
 
 async function ensureUnlocked (driver) {
   // on Travis the device is sometimes not unlocked


### PR DESCRIPTION
it seems like actually the capability is no longer needed for UIA2 driver. I was able to send unicode with without them, double checked.