### PR TITLE
fix: chromedriver version comparison in the chromedriver downloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@babel/runtime": "^7.0.0",
     "appium-adb": "^9.10.14",
     "appium-android-driver": "^5.8.10",
-    "appium-chromedriver": "^5.2.16",
+    "appium-chromedriver": "^5.3.1",
     "appium-uiautomator2-server": "^5.7.2",
     "asyncbox": "^2.3.1",
     "axios": "^1.x",


### PR DESCRIPTION
It seems like https://github.com/appium/appium-chromedriver/pull/289 ? broke the chromedriver version comparison, which was fixed in https://github.com/appium/appium-chromedriver/pull/291 . It caused https://github.com/appium/appium/issues/18368