### PR TITLE
ci: skip some find element test cases for api-25 as they are flaky

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -64,10 +64,10 @@ jobs:
     - uses: reactivecircus/android-emulator-runner@v2
       name: e2e_api${{ matrix.apiLevel }}
       with:
-        # skip find tests with api-25 as they are too flaky
         script: |
           npm run e2e-test:driver
           npm run e2e-test:commands
+          # skip find tests with api-25 as they are too flaky 
           [[ "${{ matrix.apiLevel }}" == "25" ]] || npm run e2e-test:commands:find
           npm run e2e-test:commands:general
         avd-name: ${{ env.ANDROID_AVD }}

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -64,10 +64,11 @@ jobs:
     - uses: reactivecircus/android-emulator-runner@v2
       name: e2e_api${{ matrix.apiLevel }}
       with:
+        # skip find tests with api-25 as they are too flaky
         script: |
           npm run e2e-test:driver
           npm run e2e-test:commands
-          npm run e2e-test:commands:find
+          [[ "${{ matrix.apiLevel }}" == "25" ]] || npm run e2e-test:commands:find
           npm run e2e-test:commands:general
         avd-name: ${{ env.ANDROID_AVD }}
         sdcard-path-or-size: 1500M

--- a/test/functional/commands/general/attribute-e2e-specs.js
+++ b/test/functional/commands/general/attribute-e2e-specs.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { APIDEMOS_CAPS } from '../../desired';
 import { initSession, deleteSession } from '../../helpers/session';
+import ADB from 'appium-adb';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -11,6 +12,10 @@ let animationEl;
 
 describe('apidemo - attributes', function () {
   before(async function () {
+    const adb = new ADB();
+    if (await adb.getApiLevel() === 25) {
+      return this.skip(); // this test is very flaky with API25
+    }
     driver = await initSession(APIDEMOS_CAPS);
     animationEl = await driver.$('~Animation');
     await animationEl.waitForDisplayed({ timeout: 5000 });

--- a/test/functional/commands/orientation-e2e-specs.js
+++ b/test/functional/commands/orientation-e2e-specs.js
@@ -3,6 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import { APIDEMOS_CAPS, amendCapabilities } from '../desired';
 import { initSession, deleteSession } from '../helpers/session';
+import ADB from 'appium-adb';
 
 
 chai.should();
@@ -38,7 +39,11 @@ describe('apidemo - orientation -', function () {
     });
   });
   describe('setting -', function () {
+    const adb = new ADB();
     before(async function () {
+      if (await adb.getApiLevel() === 25) {
+        return this.skip(); // this test is very flaky with API25
+      }
       driver = await initSession(amendCapabilities(APIDEMOS_CAPS, {
         'appium:appActivity': '.view.TextFields'
       }));


### PR DESCRIPTION
I noticed functional test for api-25 always fails on the some specific test cases
e.g.
https://github.com/appium/appium-uiautomator2-driver/actions/runs/4752045785/jobs/8441915286?pr=597
https://github.com/appium/appium-uiautomator2-driver/actions/runs/4744576967/jobs/8425670890?pr=596
https://github.com/appium/appium-uiautomator2-driver/actions/runs/4729447613/jobs/8391973545
https://github.com/appium/appium-uiautomator2-driver/actions/runs/4608686473/jobs/8144798439

I can't reproduce it on my laptop then it'd take time to investigate.
Could we just skip them for now?