### PR TITLE
Add api-32 and remove api-25 from E2E tests

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -18,9 +18,6 @@ jobs:
         - chromedriverVersion: "2.44"
           apiLevel: 28
           emuTag: default
-        - chromedriverVersion: "2.28"
-          apiLevel: 25
-          emuTag: default
         - chromedriverVersion: "2.20"
           apiLevel: 23
           emuTag: default
@@ -70,8 +67,7 @@ jobs:
         script: |
           npm run e2e-test:driver
           npm run e2e-test:commands
-          # skip find tests with api-25 as they are too flaky 
-          [[ "${{ matrix.apiLevel }}" == "25" ]] || npm run e2e-test:commands:find
+          npm run e2e-test:commands:find
           npm run e2e-test:commands:general
           npm run e2e-test:commands:keyboard
         avd-name: ${{ env.ANDROID_AVD }}

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -9,6 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - chromedriverVersion: "113.0.5672.63"
+          apiLevel: 32
+          emuTag: google_apis
         - chromedriverVersion: "83.0.4103.39"
           apiLevel: 30
           emuTag: google_apis

--- a/test/functional/commands/general/attribute-e2e-specs.js
+++ b/test/functional/commands/general/attribute-e2e-specs.js
@@ -2,7 +2,6 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { APIDEMOS_CAPS } from '../../desired';
 import { initSession, deleteSession } from '../../helpers/session';
-import ADB from 'appium-adb';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -12,10 +11,6 @@ let animationEl;
 
 describe('apidemo - attributes', function () {
   before(async function () {
-    const adb = new ADB();
-    if (await adb.getApiLevel() === 25) {
-      return this.skip(); // this test is very flaky with API25
-    }
     driver = await initSession(APIDEMOS_CAPS);
     animationEl = await driver.$('~Animation');
     await animationEl.waitForDisplayed({ timeout: 5000 });

--- a/test/functional/commands/orientation-e2e-specs.js
+++ b/test/functional/commands/orientation-e2e-specs.js
@@ -3,7 +3,6 @@ import chaiAsPromised from 'chai-as-promised';
 import B from 'bluebird';
 import { APIDEMOS_CAPS, amendCapabilities } from '../desired';
 import { initSession, deleteSession } from '../helpers/session';
-import ADB from 'appium-adb';
 
 
 chai.should();
@@ -39,11 +38,7 @@ describe('apidemo - orientation -', function () {
     });
   });
   describe('setting -', function () {
-    const adb = new ADB();
     before(async function () {
-      if (await adb.getApiLevel() === 25) {
-        return this.skip(); // this test is very flaky with API25
-      }
       driver = await initSession(amendCapabilities(APIDEMOS_CAPS, {
         'appium:appActivity': '.view.TextFields'
       }));

--- a/test/functional/commands/viewport-e2e-specs.js
+++ b/test/functional/commands/viewport-e2e-specs.js
@@ -3,7 +3,6 @@ import chaiAsPromised from 'chai-as-promised';
 import sharp from 'sharp';
 import { SCROLL_CAPS } from '../desired';
 import { initSession, deleteSession } from '../helpers/session';
-import ADB from 'appium-adb';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -11,13 +10,8 @@ chai.use(chaiAsPromised);
 let driver;
 
 describe('testViewportCommands', function () {
-  const adb = new ADB();
 
   before(async function () {
-    if (await adb.getApiLevel() === 25) {
-      // very flakey with API25
-      return this.skip();
-    }
     driver = await initSession(SCROLL_CAPS);
   });
   after(async function () {


### PR DESCRIPTION
This PR stops running E2E tests with api-25 and add api-32 instead. 
Ref. https://github.com/appium/appium-uiautomator2-driver/pull/598#issuecomment-1519061054