### PR TITLE
docs: address noReset in the enforceAppInstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ appium:otherApps | Allows to set one or more comma-separated paths to Android pa
 appium:uninstallOtherPackages | Allows to set one or more comma-separated package identifiers to be uninstalled from the device before a test starts
 appium:allowTestPackages | If set to `true` then it would be possible to use packages built with the test flag for the automated testing (literally adds `-t` flag to the `adb install` command). `false` by default
 appium:remoteAppsCacheLimit | Sets the maximum amount of application packages to be cached on the device under test. This is needed for devices that don't support streamed installs (Android 7 and below), because ADB must push app packages to the device first in order to install them, which takes some time. Setting this capability to zero disables apps caching. `10` by default.
-appium:enforceAppInstall | If set to `true` then the application under test is always reinstalled even if a newer version of it already exists on the device under test. `false` by default
+appium:enforceAppInstall | If set to `true` then the application under test is always reinstalled even if a newer version of it already exists on the device under test. This does not affect anything if `"appium:noReset": true` was given as skipped. `false` by default
 
 ### App Localization
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ appium:otherApps | Allows to set one or more comma-separated paths to Android pa
 appium:uninstallOtherPackages | Allows to set one or more comma-separated package identifiers to be uninstalled from the device before a test starts
 appium:allowTestPackages | If set to `true` then it would be possible to use packages built with the test flag for the automated testing (literally adds `-t` flag to the `adb install` command). `false` by default
 appium:remoteAppsCacheLimit | Sets the maximum amount of application packages to be cached on the device under test. This is needed for devices that don't support streamed installs (Android 7 and below), because ADB must push app packages to the device first in order to install them, which takes some time. Setting this capability to zero disables apps caching. `10` by default.
-appium:enforceAppInstall | If set to `true` then the application under test is always reinstalled even if a newer version of it already exists on the device under test. This does not affect anything if `"appium:noReset": true` was given as skipped. `false` by default
+appium:enforceAppInstall | If set to `true` then the application under test is always reinstalled even if a newer version of it already exists on the device under test. This capability has no effect if `appium:noReset` is set to `true`. `false` by default
 
 ### App Localization
 


### PR DESCRIPTION
I got a question about `enforceAppInstall` with noReset capability. It would be helpful to explain the relationship in the readme briefly.