### PR TITLE
chore: add logging for mjpeg broadcast request

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -334,6 +334,8 @@ class AndroidUiautomator2Driver extends BaseDriver {
 
   async allocateMjpegServerPort () {
     if (this.opts.mjpegServerPort) {
+      this.log.debug(`MJPEG broadcasting requested, forwarding MJPEG server port ${MJPEG_SERVER_DEVICE_PORT} ` +
+        `to local port ${this.opts.mjpegServerPort}`);
       await this.adb.forwardPort(this.opts.mjpegServerPort, MJPEG_SERVER_DEVICE_PORT);
     }
   }


### PR DESCRIPTION
This adds logging for the port forwarding done as part of an MJPEG broadcasting request. Similar to the log message for forwarding the UiAutomator2 server port in `allocateSystemPort()`.