### PR TITLE
refactor: Optimize server packages installation

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -28,7 +28,6 @@ jobs:
           apiLevel: 23
           emuTag: default
           arch: x86
-      fail-fast: false
 
     env:
       CI: true

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -2,6 +2,9 @@ name: Functional Tests
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -25,6 +28,7 @@ jobs:
           apiLevel: 23
           emuTag: default
           arch: x86
+      fail-fast: false
 
     env:
       CI: true

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -68,50 +68,31 @@ class UiAutomator2Server {
       appId,
     };
 
-    if (!await helpers.isWriteable(appPath)) {
-      this.log.info(
-        `Server package at '${appPath}' is not writeable. ` +
-        `Will copy it into the temporary location at '${tmpRoot}' as a workaround. ` +
-        `Consider making this file writeable manually in order to improve the performance of session startup.`
-      );
-      const dstPath = path.resolve(tmpRoot, path.basename(appPath));
-      await fs.copyFile(appPath, dstPath);
-      resultInfo.appPath = dstPath;
+    if (await this.adb.checkApkCert(resultInfo.appPath, appId)) {
+      resultInfo.wasSigned = true;
+    } else {
+      if (!await helpers.isWriteable(appPath)) {
+        this.log.warn(
+          `Server package at '${appPath}' is not writeable. ` +
+          `Will copy it into the temporary location at '${tmpRoot}' as a workaround. ` +
+          `Consider making this file writeable manually in order to improve the performance of session startup.`
+        );
+        const dstPath = path.resolve(tmpRoot, path.basename(appPath));
+        await fs.copyFile(appPath, dstPath);
+        resultInfo.appPath = dstPath;
+      }
+      await helpers.signApp(this.adb, resultInfo.appPath);
     }
 
     if (appId === SERVER_TEST_PACKAGE_ID && await this.adb.isAppInstalled(appId)) {
       // There is no point in getting the state for the test server,
       // since it does not contain any version info
-      resultInfo.installState = this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED;
+      resultInfo.installState = this.adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED;
     } else if (appId === SERVER_PACKAGE_ID) {
       resultInfo.installState = await this.adb.getApplicationInstallState(resultInfo.appPath, appId);
     }
 
-    if (await this.adb.checkApkCert(resultInfo.appPath, appId)) {
-      resultInfo.wasSigned = true;
-    } else {
-      await helpers.signApp(this.adb, resultInfo.appPath);
-    }
-
     return resultInfo;
-  }
-
-  async deployServerPackage(appId, appPath, shouldUninstall, shouldInstall, installTimeout) {
-    if (shouldUninstall) {
-      try {
-        await this.adb.uninstallApk(appId);
-      } catch (err) {
-        this.log.warn(`Error uninstalling '${appId}': ${err.message}`);
-      }
-    }
-    if (shouldInstall) {
-      await this.adb.install(appPath, {
-        noIncremental: true,
-        replace: true,
-        timeout: installTimeout,
-        timeoutCapName: 'uiautomator2ServerInstallTimeout'
-      });
-    }
   }
 
   /**
@@ -134,47 +115,43 @@ class UiAutomator2Server {
         ].map(({appPath, appId}) => this.prepareServerPackage(appPath, appId, tmpRoot))
       );
 
-      let shouldUninstallServerPackages = false;
-      let shouldInstallServerPackages = false;
-      for (const {appId, wasSigned, installState} of packagesInfo) {
-        if (appId === SERVER_TEST_PACKAGE_ID) {
-          const isAppInstalled = installState !== this.adb.APP_INSTALL_STATE.NOT_INSTALLED;
-
-          if (!wasSigned) {
-            shouldUninstallServerPackages = shouldUninstallServerPackages || isAppInstalled;
-            shouldInstallServerPackages = true;
-          }
-
-          if (!isAppInstalled) {
-            shouldInstallServerPackages = true;
-          }
-          continue;
-        }
-
-        this.log.debug(`${appId} installation state: ${installState}`);
-        if (wasSigned) {
-          shouldUninstallServerPackages = shouldUninstallServerPackages || ![
-            this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
-          ].includes(installState);
-        } else {
-          shouldUninstallServerPackages = shouldUninstallServerPackages || [
-            this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
-            this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
-          ].includes(installState);
-        }
-        shouldInstallServerPackages = shouldInstallServerPackages || shouldUninstallServerPackages || [
-          this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
-        ].includes(installState);
-      }
+      this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
+      // We want to enforce uninstall in case the current server package has not been signed properly
+      // or if any of server packages is not installed, while the other does
+      const shouldUninstallServerPackages = packagesInfo.some(({wasSigned}) => !wasSigned)
+        || (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED)
+            && !packagesInfo.every(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED));
+      // Install must always follow uninstall. Also, perform the install if
+      // any of server packages is not installed or is outdated
+      const shouldInstallServerPackages = shouldUninstallServerPackages || packagesInfo.some(({installState}) => [
+        this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
+        this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+      ].includes(installState));
       this.log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
       if (shouldInstallServerPackages && shouldUninstallServerPackages) {
         this.log.info('Full packages reinstall is going to be performed');
       }
-      await B.all(
-        packagesInfo.map(({appId, appPath}) => this.deployServerPackage(
-          appId, appPath, shouldUninstallServerPackages, shouldInstallServerPackages, installTimeout
-        ))
-      );
+      if (shouldUninstallServerPackages) {
+        const silentUninstallPkg = async (pkgId) => {
+          try {
+            await this.adb.uninstallApk(pkgId);
+          } catch (err) {
+            this.log.info(`Cannot uninstall '${pkgId}': ${err.message}`);
+          }
+        };
+        await B.all(packagesInfo.map(({appId}) => silentUninstallPkg(appId)));
+      }
+      if (shouldInstallServerPackages) {
+        const installPkg = async (pkgPath) => {
+          await this.adb.install(pkgPath, {
+            noIncremental: true,
+            replace: true,
+            timeout: installTimeout,
+            timeoutCapName: 'uiautomator2ServerInstallTimeout'
+          });
+        };
+        await B.all(packagesInfo.map(({appPath}) => installPkg(appPath)));
+      }
     } finally {
       await fs.rimraf(tmpRoot);
     }

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -60,6 +60,60 @@ class UiAutomator2Server {
     this.jwproxy.didInstrumentationExit = false;
   }
 
+  async prepareServerPackage(appPath, appId, tmpRoot) {
+    const resultInfo = {
+      wasSigned: false,
+      installState: this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
+      appPath,
+      appId,
+    };
+
+    if (!await helpers.isWriteable(appPath)) {
+      this.log.info(
+        `Server package at '${appPath}' is not writeable. ` +
+        `Will copy it into the temporary location at '${tmpRoot}' as a workaround. ` +
+        `Consider making this file writeable manually in order to improve the performance of session startup.`
+      );
+      const dstPath = path.resolve(tmpRoot, path.basename(appPath));
+      await fs.copyFile(appPath, dstPath);
+      resultInfo.appPath = dstPath;
+    }
+
+    if (appId === SERVER_TEST_PACKAGE_ID && await this.adb.isAppInstalled(appId)) {
+      // There is no point in getting the state for the test server,
+      // since it does not contain any version info
+      resultInfo.installState = this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED;
+    } else if (appId === SERVER_PACKAGE_ID) {
+      resultInfo.installState = await this.adb.getApplicationInstallState(resultInfo.appPath, appId);
+    }
+
+    if (await this.adb.checkApkCert(resultInfo.appPath, appId)) {
+      resultInfo.wasSigned = true;
+    } else {
+      await helpers.signApp(this.adb, resultInfo.appPath);
+    }
+
+    return resultInfo;
+  }
+
+  async deployServerPackage(appId, appPath, shouldUninstall, shouldInstall, installTimeout) {
+    if (shouldUninstall) {
+      try {
+        await this.adb.uninstallApk(appId);
+      } catch (err) {
+        this.log.warn(`Error uninstalling '${appId}': ${err.message}`);
+      }
+    }
+    if (shouldInstall) {
+      await this.adb.install(appPath, {
+        noIncremental: true,
+        replace: true,
+        timeout: installTimeout,
+        timeoutCapName: 'uiautomator2ServerInstallTimeout'
+      });
+    }
+  }
+
   /**
    * Installs the apks on to the device or emulator.
    *
@@ -67,43 +121,26 @@ class UiAutomator2Server {
    */
   async installServerApk (installTimeout = SERVER_INSTALL_RETRIES * 1000) {
     const tmpRoot = await tempDir.openDir();
-    const packageInfosMapper = async ({appPath, appId}) => {
-      if (await helpers.isWriteable(appPath)) {
-        return { appPath, appId };
-      }
-
-      this.log.info(`Server package at '${appPath}' is not writeable. ` +
-        `Will copy it into the temporary location at '${tmpRoot}' as a workaround. ` +
-        `Consider making this file writeable manually in order to improve the performance of session startup.`);
-      const dstPath = path.resolve(tmpRoot, path.basename(appPath));
-      await fs.copyFile(appPath, dstPath);
-      return {
-        appPath: dstPath,
-        appId,
-      };
-    };
-
     try {
-      const packagesInfo = await B.all(B.map([
-        {
-          appPath: apkPath,
-          appId: SERVER_PACKAGE_ID,
-        }, {
-          appPath: testApkPath,
-          appId: SERVER_TEST_PACKAGE_ID,
-        },
-      ], packageInfosMapper));
+      const packagesInfo = await B.all(
+        [
+          {
+            appPath: apkPath,
+            appId: SERVER_PACKAGE_ID,
+          }, {
+            appPath: testApkPath,
+            appId: SERVER_TEST_PACKAGE_ID,
+          },
+        ].map(({appPath, appId}) => this.prepareServerPackage(appPath, appId, tmpRoot))
+      );
 
       let shouldUninstallServerPackages = false;
       let shouldInstallServerPackages = false;
-      for (const {appId, appPath} of packagesInfo) {
+      for (const {appId, wasSigned, installState} of packagesInfo) {
         if (appId === SERVER_TEST_PACKAGE_ID) {
-          const isAppInstalled = await this.adb.isAppInstalled(appId);
+          const isAppInstalled = installState !== this.adb.APP_INSTALL_STATE.NOT_INSTALLED;
 
-          // There is no point in getting the state for test server,
-          // since it does not contain version info
-          if (!await this.adb.checkApkCert(appPath, appId)) {
-            await helpers.signApp(this.adb, appPath);
+          if (!wasSigned) {
             shouldUninstallServerPackages = shouldUninstallServerPackages || isAppInstalled;
             shouldInstallServerPackages = true;
           }
@@ -114,44 +151,30 @@ class UiAutomator2Server {
           continue;
         }
 
-        const appState = await this.adb.getApplicationInstallState(appPath, appId);
-        this.log.debug(`${appId} installation state: ${appState}`);
-        if (await this.adb.checkApkCert(appPath, appId)) {
+        this.log.debug(`${appId} installation state: ${installState}`);
+        if (wasSigned) {
+          shouldUninstallServerPackages = shouldUninstallServerPackages || ![
+            this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
+          ].includes(installState);
+        } else {
           shouldUninstallServerPackages = shouldUninstallServerPackages || [
             this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
             this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
-          ].includes(appState);
-        } else {
-          await helpers.signApp(this.adb, appPath);
-          shouldUninstallServerPackages = shouldUninstallServerPackages || ![
-            this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
-          ].includes(appState);
+          ].includes(installState);
         }
         shouldInstallServerPackages = shouldInstallServerPackages || shouldUninstallServerPackages || [
           this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
-        ].includes(appState);
+        ].includes(installState);
       }
       this.log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
       if (shouldInstallServerPackages && shouldUninstallServerPackages) {
         this.log.info('Full packages reinstall is going to be performed');
       }
-      for (const {appId, appPath} of packagesInfo) {
-        if (shouldUninstallServerPackages) {
-          try {
-            await this.adb.uninstallApk(appId);
-          } catch (err) {
-            this.log.warn(`Error uninstalling '${appId}': ${err.message}`);
-          }
-        }
-        if (shouldInstallServerPackages) {
-          await this.adb.install(appPath, {
-            noIncremental: true,
-            replace: true,
-            timeout: installTimeout,
-            timeoutCapName: 'uiautomator2ServerInstallTimeout'
-          });
-        }
-      }
+      await B.all(
+        packagesInfo.map(({appId, appPath}) => this.deployServerPackage(
+          appId, appPath, shouldUninstallServerPackages, shouldInstallServerPackages, installTimeout
+        ))
+      );
     } finally {
       await fs.rimraf(tmpRoot);
     }

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -38,7 +38,7 @@ async function attemptToDismissAlert (caps) {
       await retryInterval(ALERT_CHECK_RETRIES, ALERT_CHECK_INTERVAL, async function () {
         let btn;
         try {
-          btn = await driver.$(`#${btnId}`);
+          btn = await driver.$(`id=${btnId}`);
           alertFound = true;
         } catch (ign) {
           // no element found, so just finish

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -31,8 +31,7 @@ describe('UiAutomator2', function () {
     });
 
     it('new server and server.test are older than installed version', async function () {
-      mocks.helpers.expects('isWriteable').atLeast(1)
-        .returns(true);
+      mocks.helpers.expects('isWriteable').never();
 
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
@@ -55,8 +54,7 @@ describe('UiAutomator2', function () {
     });
 
     it('new server and server.test are newer than installed version', async function () {
-      mocks.helpers.expects('isWriteable').atLeast(1)
-        .returns(true);
+      mocks.helpers.expects('isWriteable').never();
 
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
@@ -79,8 +77,7 @@ describe('UiAutomator2', function () {
     });
 
     it('new server and server.test are the same as installed version', async function () {
-      mocks.helpers.expects('isWriteable').atLeast(1)
-        .returns(true);
+      mocks.helpers.expects('isWriteable').never();
 
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
@@ -128,8 +125,7 @@ describe('UiAutomator2', function () {
     });
 
     it('version numbers of new server and server.test are unknown', async function () {
-      mocks.helpers.expects('isWriteable').atLeast(1)
-        .returns(true);
+      mocks.helpers.expects('isWriteable').never();
 
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
@@ -153,8 +149,7 @@ describe('UiAutomator2', function () {
 
 
     it('a server is installed but server.test is not', async function () {
-      mocks.helpers.expects('isWriteable').atLeast(1)
-        .returns(true);
+      mocks.helpers.expects('isWriteable').never();
 
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()


### PR DESCRIPTION
It makes sense to perform some server installation actions in parallel to save some time on session startup.
The change should also make the current code more readable