### PR TITLE
chore: add basic doc gen

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+INHERIT: ./node_modules/@appium/docutils/base-mkdocs.yml
+docs_dir: docs
+site_dir: site
+site_name: appium-uiautomator2-driver
+repo_url: git+https://github.com/appium/appium-uiautomator2-driver.git
+repo_name: appium/appium-uiautomator2-driver
+site_description: UiAutomator2 integration for Appium
+nav:
+  - Reference:
+      - reference/commands/appium-uiautomator2-driver.md

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "type-fest": "^3.12.0"
   },
   "devDependencies": {
-    "@appium/docutils": "^0.4.2",
+    "@appium/docutils": "^0.4.4",
     "@appium/eslint-config-appium": "^8.0.3",
     "@appium/eslint-config-appium-ts": "^0.3.1",
     "@appium/support": "^4.0.1",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "cleanOutputDir": true,
+  "entryPointStrategy": "packages",
+  "theme": "appium",
+  "entryPoints": ["."]
+}


### PR DESCRIPTION
This adds basic documentation generation via `appium-docs`. 

Future work should include: 

- Add the human-written docs to the nav in `mkdocs.yml`
- More descriptions of commands (in docstrings)
- Some sort of landing page or otherwise fix the broken links in the generated `README.md`
- Add a workflow to build and/or publish docs

To build & serve:

```bash
npm exec appium-docs build -- --serve
```
