### PR TITLE
chore: Disable app capability presence validation

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -2,7 +2,6 @@ import { commonCapConstraints } from 'appium-android-driver';
 
 let uiautomatorCapConstraints = {
   app: {
-    presence: true,
     isString: true
   },
   automationName: {


### PR DESCRIPTION
UIA2 driver can start sessions without app being set