### PR TITLE
fix: check if the instrumentation process stops by sending a request

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -305,6 +305,26 @@ class UiAutomator2Server {
   async cleanupAutomationLeftovers (strictCleanup = false) {
     this.log.debug(`Performing ${strictCleanup ? 'strict' : 'shallow'} cleanup of automation leftovers`);
 
+    const waitStop = async () => {
+      // Wait for the process stop by sending a status request to the port.
+      // We observed the process stop could be delayed, then it caused the process stop
+      // in the middle of session preparation. It caused invalid session error response by the uia2 server,
+      // but that was because the process stop's delay.
+      const timeout = 3000;
+      try {
+        await waitForCondition(async () => {
+          try {
+            await this.jwproxy.command('/status', 'GET');
+          } catch (err) { return true; }
+        }, {
+          waitMs: timeout,
+          intervalMs: 100,
+        });
+      } catch (err) {
+        this.log.errorAndThrow(`The instrumentation process might fail to stop within ${timeout}ms timeout.`);
+      }
+    };
+
     try {
       const {value} = (await axios({
         url: `http://${this.host}:${this.systemPort}/sessions`,
@@ -330,12 +350,14 @@ class UiAutomator2Server {
       await this.adb.forceStop(SERVER_TEST_PACKAGE_ID);
     } catch (ignore) {}
     if (!strictCleanup) {
+      await waitStop();
       return;
     }
     // https://github.com/appium/appium/issues/10749
     try {
       await this.adb.killProcessesByName('uiautomator');
     } catch (ignore) {}
+    await waitStop();
   }
 }
 

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -314,8 +314,9 @@ class UiAutomator2Server {
       try {
         await waitForCondition(async () => {
           try {
-            await this.jwproxy.command('/status', 'GET');
-          } catch (err) { return true; }
+            await this.adb.processExists(SERVER_TEST_PACKAGE_ID);
+            return true;
+          } catch (ignore) {}
         }, {
           waitMs: timeout,
           intervalMs: 100,

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -309,9 +309,9 @@ class UiAutomator2Server {
 
     const waitStop = async () => {
       // Wait for the process stop by sending a status request to the port.
-      // We observed the process stop could be delayed, then it caused the process stop
-      // in the middle of session preparation. It caused invalid session error response by the uia2 server,
-      // but that was because the process stop's delay.
+      // We observed the process stop could be delayed, thus causing unexpected crashes
+      // in the middle of the session preparation process. It caused an invalid session error response
+      // by the uia2 server, but that was because the process stop's delay.
       const timeout = 3000;
       try {
         await waitForCondition(async () => {

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -356,14 +356,12 @@ class UiAutomator2Server {
     try {
       await this.adb.forceStop(SERVER_TEST_PACKAGE_ID);
     } catch (ignore) {}
-    if (!strictCleanup) {
-      await waitStop();
-      return;
+    if (strictCleanup) {
+      // https://github.com/appium/appium/issues/10749
+      try {
+        await this.adb.killProcessesByName('uiautomator');
+      } catch (ignore) {}
     }
-    // https://github.com/appium/appium/issues/10749
-    try {
-      await this.adb.killProcessesByName('uiautomator');
-    } catch (ignore) {}
     await waitStop();
   }
 }

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -328,7 +328,7 @@ class UiAutomator2Server {
           intervalMs: 100,
         });
       } catch (err) {
-        this.log.errorAndThrow(`The instrumentation process might fail to stop within ${timeout}ms timeout.`);
+        this.log.warn(`The ${SERVER_TEST_PACKAGE_ID} process might fail to stop within ${timeout}ms timeout.`);
       }
     };
 

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -305,6 +305,8 @@ class UiAutomator2Server {
   async cleanupAutomationLeftovers (strictCleanup = false) {
     this.log.debug(`Performing ${strictCleanup ? 'strict' : 'shallow'} cleanup of automation leftovers`);
 
+    const axiosTimeout = 500;
+
     const waitStop = async () => {
       // Wait for the process stop by sending a status request to the port.
       // We observed the process stop could be delayed, then it caused the process stop
@@ -314,9 +316,13 @@ class UiAutomator2Server {
       try {
         await waitForCondition(async () => {
           try {
-            await this.adb.processExists(SERVER_TEST_PACKAGE_ID);
+            await axios({
+              url: `http://${this.host}:${this.systemPort}/status`,
+              timeout: axiosTimeout,
+            });
+          } catch (err) {
             return true;
-          } catch (ignore) {}
+          }
         }, {
           waitMs: timeout,
           intervalMs: 100,
@@ -329,7 +335,7 @@ class UiAutomator2Server {
     try {
       const {value} = (await axios({
         url: `http://${this.host}:${this.systemPort}/sessions`,
-        timeout: 500,
+        timeout: axiosTimeout,
       })).data;
       const activeSessionIds = value.map(({id}) => id).filter(Boolean);
       if (activeSessionIds.length) {


### PR DESCRIPTION
I observed weird behavior on an Android 13 Samsung device. This was only a specific device so far but potentially could happen on other devices. (I mean I cannot say this does not happen on other devices)

What I saw was in a new session request from uia2 driver to the uia2 server. These are in `createSession` in `driver.js`.


- `/wd/hub/session` create session -> ok 200
- `/wd/hub/session/0e62d0be-bfb4-403e-8b85-6af9ae40fbfd/appium/device/info` -> ok
- `/wd/hub/session/0e62d0be-bfb4-403e-8b85-6af9ae40fbfd/appium/device/pixel_ratio` -> invalid session id for `0e62d0be-bfb4-403e-8b85-6af9ae40fbfd`

According to the adb log cat, it seems like the uia2 server process stop in `cleanupAutomationLeftovers`? probably delayed. So activity stop log actually existed before `/wd/hub/session` in the above, but the process kill itself conducted AFTER `/wd/hub/session/0e62d0be-bfb4-403e-8b85-6af9ae40fbfd/appium/device/info`. Then the instrumentation process started again, maybe by the instrumentation command.

So probably that happened on the device was something activity handling by the OS had delayed.

So, in this PR, I'd like to check if the `cleanupAutomationLeftovers` can ensure that the process (the same port is fine to avoid this behavior) actually stops. Then, I expect like the above weird "delay" also can be avoidable.




Error example when this check fails:

```
[AndroidUiautomator2Driver@8443 (969adba8)] socket hang up
[debug] [AndroidUiautomator2Driver@8443 (969adba8)] Matched '/status' to command name 'getStatus'
[debug] [AndroidUiautomator2Driver@8443 (969adba8)] Proxying [GET /status] to [GET http://127.0.0.1:8200/status] with no body
[AndroidUiautomator2Driver@8443 (969adba8)] socket hang up
[debug] [AndroidUiautomator2Driver@8443 (969adba8)] Matched '/status' to command name 'getStatus'
[debug] [AndroidUiautomator2Driver@8443 (969adba8)] Proxying [GET /status] to [GET http://127.0.0.1:8200/status] with no body
[AndroidUiautomator2Driver@8443 (969adba8)] socket hang up
[AndroidUiautomator2Driver@8443 (969adba8)] The instrumentation process might fail to stop within 1000ms timeout.
[debug] [AndroidUiautomator2Driver@8443 (969adba8)] Deleting UiAutomator2 session
[debug] [AndroidUiautomator2Driver@8443 (969adba8)] Deleting UiAutomator2 server session
[debug] [AndroidUiautomator2Driver@8443 (969adba8)] Matched '/' to command name 'deleteSession'
[AndroidUiautomator2Driver@8443 (969adba8)] Did not get confirmation UiAutomator2 deleteSession worked; Error was: UnknownError: An unknown server-side error occurred while processing the command. Original error: Trying to proxy a session command without session id
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell dumpsys activity services io.appium.settings/.recorder.RecorderService'
[debug] [Logcat] Stopping logcat capture
[debug] [ADB] Removing forwarded port socket connection: 8200
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 forward --remove tcp:8200'
[AndroidUiautomator2Driver@8443 (969adba8)] Restoring hidden api policy to the device default configuration
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell 'settings delete global hidden_api_policy_pre_p_apps;settings delete global hidden_api_policy_p_apps;settings delete global hidden_api_policy''
[debug] [AppiumDriver@72ca] Event 'newSessionStarted' logged at 1695178273288 (19:51:13 GMT-0700 (Pacific Daylight Time))
[debug] [AppiumDriver@72ca] Encountered internal error running command: Error: The instrumentation process might fail to stop within 1000ms timeout.
[debug] [AppiumDriver@72ca]     at Object.errorAndThrow (/Users/kazu/GitHub/appium-uiautomator2-driver/node_modules/@appium/support/lib/logging.js:115:34)
[debug] [AppiumDriver@72ca]     at waitServiceStop (/Users/kazu/GitHub/appium-uiautomator2-driver/lib/uiautomator2.js:328:18)
[debug] [AppiumDriver@72ca]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[debug] [AppiumDriver@72ca]     at UiAutomator2Server.cleanupAutomationLeftovers (/Users/kazu/GitHub/appium-uiautomator2-driver/lib/uiautomator2.js:359:7)
[debug] [AppiumDriver@72ca]     at UiAutomator2Server.startSession (/Users/kazu/GitHub/appium-uiautomator2-driver/lib/uiautomator2.js:206:5)
[debug] [AppiumDriver@72ca]     at AndroidUiautomator2Driver.startUiAutomator2Session (/Users/kazu/GitHub/appium-uiautomator2-driver/lib/driver.js:430:5)
[debug] [AppiumDriver@72ca]     at AndroidUiautomator2Driver.createSession (/Users/kazu/GitHub/appium-uiautomator2-driver/lib/driver.js:241:7)
[debug] [AppiumDriver@72ca]     at AppiumDriver.createSession (/Users/kazu/.nvm/versions/node/v18.17.1/lib/node_modules/appium/lib/appium.js:374:35)
[HTTP] <-- POST /session 500 2814 ms - 696
```