### PR TITLE
docs: update Java executeScript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,18 +532,6 @@ Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
 action | string | yes | The name or an integer code of the editor action to be executed. The following action names are supported: `normal, unspecified, none, go, search, send, next, done, previous`. Read [EditorInfo](https://developer.android.com/reference/android/view/inputmethod/EditorInfo) for more details on this topic. | search
 
-#### Examples
-
-```java
-// Java
-driver.executeScript("mobile: performEditorAction", ImmutableMap.of("action", "Go"));
-```
-
-```python
-# Python
-driver.execute_script('mobile: performEditorAction', {'action': 'previous'})
-```
-
 ### mobile: startScreenStreaming
 
 Starts device screen broadcast by creating MJPEG server. Multiple calls to this method have no effect unless the previous streaming session is stopped. This method only works if the `adb_screen_streaming` feature is enabled on the server side. It is also required that [GStreamer](https://gstreamer.freedesktop.org/) with `gst-plugins-base`, `gst-plugins-good` and `gst-plugins-bad` packages are installed and available in PATH on the server machine.

--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ Beside of standard W3C APIs the driver provides the below custom command extensi
 
 ```java
 // Java 11+
-var result = driver.executeScript("mobile: <methodName>", Map.of(
-    "arg1", "value1",
-    "arg2", "value2"
+var result = driver.executeScript("mobile: <methodName>", Map.ofEntries(
+    Map.entry("arg1", "value1"),
+    Map.entry("arg2", "value2")
     // you may add more pairs if needed or skip providing the map completely
     // if all arguments are defined as optional
 ));


### PR DESCRIPTION
* Update Java `executeScript` code example to use `Map.ofEntries` instead of `Map.of`
  * It is important to use `Map.ofEntries`, because `Map.of` is limited to 10 key-value pairs, and some extension methods support more than 10 parameters, e.g. `mobile: startActivity`
* Remove code example for `mobile: performEditorAction`, since now there are common examples at the start of the extensions section