### PR TITLE
fix: bump appium android driver to 7.8.3 (for getContexts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "appium-adb": "^12.0.0",
-    "appium-android-driver": "^7.8.1",
+    "appium-android-driver": "^7.8.3",
     "appium-chromedriver": "^5.6.28",
     "appium-uiautomator2-server": "^6.0.3",
     "asyncbox": "^3.0.0",


### PR DESCRIPTION
will merge after ci passes