### PR TITLE
fix: fix `mobile: screenshots` for WDIO

### DIFF
--- a/lib/commands/screenshot.js
+++ b/lib/commands/screenshot.js
@@ -83,7 +83,8 @@ export async function mobileScreenshots(opts = {}) {
     );
 
   const {displayId} = opts;
-  const displayIdStr = _.isNaN(displayId) ? null : `${displayId}`;
+  // @ts-ignore isNaN works properly here
+  const displayIdStr = isNaN(displayId) ? null : `${displayId}`;
   if (displayIdStr) {
     if (!infos[displayIdStr]) {
       throw new Error(


### PR DESCRIPTION
It seems that `mobile: screenshots` does not work in the Inspector (which is based on WDIO):
```
[AndroidUiautomator2Driver@2eaa (71335d72)] Calling AppiumDriver.execute() with args: ["mobile: screenshots",[],"71335d72-7790-446c-8fe0-ed7e7f070a3c"]
[AndroidUiautomator2Driver@2eaa (71335d72)] Executing method 'mobile: screenshots'
[ADB] Running '/Users/alvaro/Library/Android/sdk/platform-tools/adb -P 5037 -s <udid> shell dumpsys SurfaceFlinger --display-id'
[AndroidUiautomator2Driver@2eaa (71335d72)] Parsed Android display infos: {"4619827677550801152":{"id":"4619827677550801152","isDefault":true,"name":"Common Panel"}}
[AndroidUiautomator2Driver@2eaa (71335d72)] Encountered internal error running command: Error: The provided display identifier 'undefined' is not known. Only the following displays have been detected: {"4619827677550801152":{"id":"4619827677550801152","isDefault":true,"name":"Common Panel"}}
```

This is because WDIO requires the argument object to be an array, even if there are no arguments. In this case it looks like it is somehow converted to `undefined`. `_.isNaN(undefined)` returns `false`, which causes the error. However, [Espresso driver uses the global `isNaN`](https://github.com/appium/appium-espresso-driver/blob/master/lib/commands/screenshot.js#L55), and `isNaN(undefined)` returns `true`, which works fine in the Inspector.

This PR therefore changes the argument check to use the global `isNaN`, aligning with Espresso.