### PR TITLE
chore: bump uia2 server that has androidx.test.uiautomator:uiautomator:2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "appium-adb": "^12.0.0",
     "appium-android-driver": "^9.0.0",
     "appium-chromedriver": "^5.6.28",
-    "appium-uiautomator2-server": "^7.0.0",
+    "appium-uiautomator2-server": "^7.0.1",
     "asyncbox": "^3.0.0",
     "axios": "^1.6.5",
     "bluebird": "^3.5.1",


### PR DESCRIPTION
No issue was observed in https://github.com/appium/appium-uiautomator2-server/pull/615 for now, so I think we can bump the server version as chore. (not feat level).

Closes https://github.com/appium/appium/issues/19597

I'll merge this after CI check passes