### PR TITLE
chore: Skip signature checks of server packages

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -6,13 +6,9 @@ import {
   TEST_APK_PATH as testApkPath,
   version as serverVersion
 } from 'appium-uiautomator2-server';
-import {
-  util, logger, tempDir, fs, timing
-} from 'appium/support';
+import { util, logger, timing } from 'appium/support';
 import B from 'bluebird';
-import {isWriteable, signApp} from './helpers';
 import axios from 'axios';
-import path from 'path';
 
 const REQD_PARAMS = ['adb', 'tmpDir', 'host', 'systemPort', 'devicePort', 'disableWindowAnimation'];
 const SERVER_LAUNCH_TIMEOUT = 30000;
@@ -78,29 +74,17 @@ class UiAutomator2Server {
     this.jwproxy.didInstrumentationExit = false;
   }
 
-  async prepareServerPackage(appPath, appId, tmpRoot) {
+  /**
+   * @param {string} appPath
+   * @param {string} appId
+   * @returns {Promise<{installState: import('appium-adb').InstallState, appPath: string; appId: string}>}
+   */
+  async prepareServerPackage(appPath, appId) {
     const resultInfo = {
-      wasSigned: false,
       installState: this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
       appPath,
       appId,
     };
-
-    if (await this.adb.checkApkCert(resultInfo.appPath, appId)) {
-      resultInfo.wasSigned = true;
-    } else {
-      if (!await isWriteable(appPath)) {
-        this.log.warn(
-          `Server package at '${appPath}' is not writeable. ` +
-          `Will copy it into the temporary location at '${tmpRoot}' as a workaround. ` +
-          `Consider making this file writeable manually in order to improve the performance of session startup.`
-        );
-        const dstPath = path.resolve(tmpRoot, path.basename(appPath));
-        await fs.copyFile(appPath, dstPath);
-        resultInfo.appPath = dstPath;
-      }
-      await signApp(this.adb, resultInfo.appPath);
-    }
 
     if (appId === SERVER_TEST_PACKAGE_ID && await this.adb.isAppInstalled(appId)) {
       // There is no point in getting the state for the test server,
@@ -119,59 +103,52 @@ class UiAutomator2Server {
    * @param {number} installTimeout - Installation timeout
    */
   async installServerApk (installTimeout = SERVER_INSTALL_RETRIES * 1000) {
-    const tmpRoot = await tempDir.openDir();
-    try {
-      const packagesInfo = await B.all(
-        [
-          {
-            appPath: apkPath,
-            appId: SERVER_PACKAGE_ID,
-          }, {
-            appPath: testApkPath,
-            appId: SERVER_TEST_PACKAGE_ID,
-          },
-        ].map(({appPath, appId}) => this.prepareServerPackage(appPath, appId, tmpRoot))
-      );
+    const packagesInfo = await B.all(
+      [
+        {
+          appPath: apkPath,
+          appId: SERVER_PACKAGE_ID,
+        }, {
+          appPath: testApkPath,
+          appId: SERVER_TEST_PACKAGE_ID,
+        },
+      ].map(({appPath, appId}) => this.prepareServerPackage(appPath, appId))
+    );
 
-      this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
-      // We want to enforce uninstall in case the current server package has not been signed properly
-      // or if any of server packages is not installed, while the other does
-      const shouldUninstallServerPackages = packagesInfo.some(({wasSigned}) => !wasSigned)
-        || (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED)
-            && !packagesInfo.every(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED));
-      // Install must always follow uninstall. Also, perform the install if
-      // any of server packages is not installed or is outdated
-      const shouldInstallServerPackages = shouldUninstallServerPackages || packagesInfo.some(({installState}) => [
-        this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
-        this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
-      ].includes(installState));
-      this.log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
-      if (shouldInstallServerPackages && shouldUninstallServerPackages) {
-        this.log.info('Full packages reinstall is going to be performed');
-      }
-      if (shouldUninstallServerPackages) {
-        const silentUninstallPkg = async (pkgId) => {
-          try {
-            await this.adb.uninstallApk(pkgId);
-          } catch (err) {
-            this.log.info(`Cannot uninstall '${pkgId}': ${err.message}`);
-          }
-        };
-        await B.all(packagesInfo.map(({appId}) => silentUninstallPkg(appId)));
-      }
-      if (shouldInstallServerPackages) {
-        const installPkg = async (pkgPath) => {
-          await this.adb.install(pkgPath, {
-            noIncremental: true,
-            replace: true,
-            timeout: installTimeout,
-            timeoutCapName: 'uiautomator2ServerInstallTimeout'
-          });
-        };
-        await B.all(packagesInfo.map(({appPath}) => installPkg(appPath)));
-      }
-    } finally {
-      await fs.rimraf(tmpRoot);
+    this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
+    // Enforce server packages reinstall if any of the packages is not installed, while the other is
+    const shouldUninstallServerPackages = (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED)
+          && !packagesInfo.every(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED));
+    // Install must always follow uninstall. Also, perform the install if
+    // any of server packages is not installed or is outdated
+    const shouldInstallServerPackages = shouldUninstallServerPackages || packagesInfo.some(({installState}) => [
+      this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
+      this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+    ].includes(installState));
+    this.log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
+    if (shouldInstallServerPackages && shouldUninstallServerPackages) {
+      this.log.info('Full packages reinstall is going to be performed');
+    }
+    if (shouldUninstallServerPackages) {
+      const silentUninstallPkg = async (pkgId) => {
+        try {
+          await this.adb.uninstallApk(pkgId);
+        } catch (err) {
+          this.log.info(`Cannot uninstall '${pkgId}': ${err.message}`);
+        }
+      };
+      await B.all(packagesInfo.map(({appId}) => silentUninstallPkg(appId)));
+    }
+    if (shouldInstallServerPackages) {
+      const installPkg = async (pkgPath) => {
+        await this.adb.install(pkgPath, {
+          noIncremental: true,
+          replace: true,
+          timeout: installTimeout,
+          timeoutCapName: 'uiautomator2ServerInstallTimeout'
+        });
+      };
+      await B.all(packagesInfo.map(({appPath}) => installPkg(appPath)));
     }
 
     await this.verifyServicesAvailability();


### PR DESCRIPTION
It's actually only taking time since we always preresign server packages automatically upon package release.