### PR TITLE
ci: Enable KVM group perms

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -44,7 +44,7 @@ jobs:
       TEST_PASS_THRESHOLD: 10
     # No hardware acceleration is available for emulators on Ubuntu:
     # https://github.com/marketplace/actions/android-emulator-runner#can-i-use-this-action-on-linux-vms
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
@@ -76,6 +76,11 @@ jobs:
           2>&1 > "$cwd/appium.log" &
         popd
       name: Start Appium server
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
     - run: nohup adb logcat > logcat.log &
       name: Capture logcat
     - uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -51,9 +51,7 @@ jobs:
       with:
         node-version: lts/*
         check-latest: true
-    - run: |
-        sudo apt-get update
-        sudo apt-get install xq
+    - run: curl -sSL https://bit.ly/install-xq | sudo bash
     - run: |
         npm install mocha-multi-reporters --save-dev
         npm install -g appium
@@ -94,7 +92,6 @@ jobs:
         api-level: ${{ matrix.apiLevel }}
         disable-spellchecker: true
         target: ${{ matrix.emuTag }}
-        arch: ${{ matrix.arch }}
         ram-size: 4096M
         heap-size: 1024M
     - name: Save logcat output

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -52,15 +52,14 @@ jobs:
         node-version: lts/*
         check-latest: true
     - run: |
-        brew install xq
         npm install mocha-multi-reporters --save-dev
         npm install -g appium
         npm install --no-save mjpeg-consumer
       name: Install dev dependencies
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '11'
+    # - uses: actions/setup-java@v3
+    #   with:
+    #     distribution: 'temurin'
+    #     java-version: '11'
     - run: |
         cwd=$(pwd)
         pushd "$cwd"

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -66,8 +66,6 @@ jobs:
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
-    - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
     - name: AVD cache
       uses: actions/cache@v3
       id: avd-cache
@@ -76,6 +74,15 @@ jobs:
           ~/.android/avd/*
           ~/.android/adb*
         key: avd-${{ matrix.apiLevel }}
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
     - run: |
         cwd=$(pwd)
         pushd "$cwd"

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -88,12 +88,9 @@ jobs:
       with:
         script: bash -xe scripts/run-functional-tests.sh
         avd-name: ${{ env.ANDROID_AVD }}
-        sdcard-path-or-size: 1500M
         api-level: ${{ matrix.apiLevel }}
         disable-spellchecker: true
         target: ${{ matrix.emuTag }}
-        ram-size: 4096M
-        heap-size: 1024M
     - name: Save logcat output
       if: ${{ always() }}
       uses: actions/upload-artifact@master

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -61,12 +61,19 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
     - run: |
         cwd=$(pwd)
         pushd "$cwd"
         cd ~
         CHROMEDRIVER_VERSION="${{ matrix.chromedriverVersion }}" appium driver install --source=local "$cwd"
-        # appium driver doctor uiautomator2
+        appium driver doctor uiautomator2
         nohup appium server \
           --port=$APPIUM_TEST_SERVER_PORT \
           --address=$APPIUM_TEST_SERVER_HOST \
@@ -76,11 +83,6 @@ jobs:
           2>&1 > "$cwd/appium.log" &
         popd
       name: Start Appium server
-    - name: Enable KVM group perms
-      run: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
     - run: nohup adb logcat > logcat.log &
       name: Capture logcat
     - uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -57,10 +57,10 @@ jobs:
         npm install -g appium
         npm install --no-save mjpeg-consumer
       name: Install dev dependencies
-    # - uses: actions/setup-java@v3
-    #   with:
-    #     distribution: 'temurin'
-    #     java-version: '11'
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - run: |
         cwd=$(pwd)
         pushd "$cwd"
@@ -88,13 +88,11 @@ jobs:
       with:
         script: bash -xe scripts/run-functional-tests.sh
         avd-name: ${{ env.ANDROID_AVD }}
-        sdcard-path-or-size: 1500M
         api-level: ${{ matrix.apiLevel }}
         disable-spellchecker: true
+        disable-animations: true
         target: ${{ matrix.emuTag }}
         arch: ${{ matrix.arch }}
-        ram-size: 4096M
-        heap-size: 1024M
     - name: Save logcat output
       if: ${{ always() }}
       uses: actions/upload-artifact@master

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -52,7 +52,9 @@ jobs:
         node-version: lts/*
         check-latest: true
     - run: |
-        apt-get install xq
+        sudo apt-get update
+        sudo apt-get install xq
+    - run: |
         npm install mocha-multi-reporters --save-dev
         npm install -g appium
         npm install --no-save mjpeg-consumer

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # - chromedriverVersion: "113.0.5672.63"
-        #   apiLevel: 32
-        #   emuTag: google_apis
-        #   arch: x86_64
+        - chromedriverVersion: "113.0.5672.63"
+          apiLevel: 32
+          emuTag: google_apis
+          arch: x86_64
         - chromedriverVersion: "83.0.4103.39"
           apiLevel: 30
           emuTag: google_apis

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -52,6 +52,7 @@ jobs:
         node-version: lts/*
         check-latest: true
     - run: |
+        apt-get install xq
         npm install mocha-multi-reporters --save-dev
         npm install -g appium
         npm install --no-save mjpeg-consumer

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -88,9 +88,13 @@ jobs:
       with:
         script: bash -xe scripts/run-functional-tests.sh
         avd-name: ${{ env.ANDROID_AVD }}
+        sdcard-path-or-size: 1500M
         api-level: ${{ matrix.apiLevel }}
         disable-spellchecker: true
         target: ${{ matrix.emuTag }}
+        arch: ${{ matrix.arch }}
+        ram-size: 4096M
+        heap-size: 1024M
     - name: Save logcat output
       if: ${{ always() }}
       uses: actions/upload-artifact@master

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -66,6 +66,8 @@ jobs:
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
     - name: AVD cache
       uses: actions/cache@v3
       id: avd-cache

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -65,7 +65,7 @@ jobs:
         pushd "$cwd"
         cd ~
         CHROMEDRIVER_VERSION="${{ matrix.chromedriverVersion }}" appium driver install --source=local "$cwd"
-        appium driver doctor uiautomator2
+        # appium driver doctor uiautomator2
         nohup appium server \
           --port=$APPIUM_TEST_SERVER_PORT \
           --address=$APPIUM_TEST_SERVER_HOST \

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -68,6 +68,14 @@ jobs:
         sudo udevadm trigger --name-match=kvm
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
+    - name: AVD cache
+      uses: actions/cache@v3
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.apiLevel }}
     - run: |
         cwd=$(pwd)
         pushd "$cwd"
@@ -90,6 +98,7 @@ jobs:
       with:
         script: bash -xe scripts/run-functional-tests.sh
         avd-name: ${{ env.ANDROID_AVD }}
+        force-avd-creation: false
         api-level: ${{ matrix.apiLevel }}
         disable-spellchecker: true
         disable-animations: true


### PR DESCRIPTION
Just curious about Ubuntu and Enable KVM group perms

https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/
https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners


https://github.com/appium/appium-uiautomator2-driver/actions/runs/8012939666

Maybe this is the most recent succeeded cases:

![Screenshot 2024-05-01 at 11 09 46 PM](https://github.com/appium/appium-uiautomator2-driver/assets/5511591/00accba5-03f9-4cb9-a156-73b69cc7a5f5)
