### PR TITLE
chore: use latest io.appium.settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "axios": "^1.6.5",
     "bluebird": "^3.5.1",
     "css-selector-parser": "^3.0.0",
-    "io.appium.settings": "^5.7.2",
+    "io.appium.settings": "^5.12.0",
     "lodash": "^4.17.4",
     "portscanner": "^2.2.0",
     "source-map-support": "^0.x",


### PR DESCRIPTION
To use api level 32 built settings apk