### PR TITLE
fix: Add a workaround for wrong adb exit code on service stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "appium-adb": "^12.2.0",
-    "appium-android-driver": "^9.6.0",
+    "appium-android-driver": "^9.6.5",
     "appium-chromedriver": "^5.6.28",
     "appium-uiautomator2-server": "^7.0.1",
     "asyncbox": "^3.0.0",


### PR DESCRIPTION
to create a version with https://github.com/appium/appium-android-driver/pull/939

I'll merge after CI passes