### PR TITLE
fix: uninstall installed uia2 servers if they were greater than on-going session

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -103,7 +103,11 @@ class UiAutomator2Server {
    * @property {string} appPath
    * @property {string} appId
    */
+
   /**
+   * If the given package information includes servers should uninstall befoer installing new UIA2 servers.
+   * For example, if the servers on the device is newer than servers UIA2 driver wants to use for the session.
+   *
    * @param {PackageInfo[]} packagesInfo
    * @returns {boolean}
    */
@@ -113,6 +117,8 @@ class UiAutomator2Server {
   }
 
   /**
+   * If the given package information includes servers which can install with current UIA2 driver has.
+   *
    * @param {PackageInfo[]} packagesInfo
    * @returns {boolean}
    */

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -105,15 +105,18 @@ class UiAutomator2Server {
    */
 
   /**
-   * If the given package information includes servers should uninstall befoer installing new UIA2 servers.
-   * For example, if one of servers on the device was newer than servers current UIA2 driver wants to
+   * Checks if server components must be installed from the device under test
+   * in scope of the current driver session.
+   *
+   * For example, if one of servers on the device under test was newer than servers current UIA2 driver wants to
    * use for the session, the UIA2 driver should uninstall the installed ones in order to avoid
-   * version mismatch between the UIA2 drier and servers on the device.
-   * Also, if the device has missing servers, current UIA2 driver should uninstall all
+   * version mismatch between the UIA2 drier and servers on the device under test.
+   * Also, if the device under test has missing servers, current UIA2 driver should uninstall all
    * servers once in order to install proper servers freshly.
    *
    * @param {PackageInfo[]} packagesInfo
-   * @returns {boolean}
+   * @returns {boolean} if any of components is already installed and the other is not installed
+   *                    or the installed one has a newer version.
    */
   shouldUninstallServerPackages(packagesInfo = []) {
     const isAnyComponentInstalled = packagesInfo.some(

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -115,7 +115,7 @@ class UiAutomator2Server {
    * servers once in order to install proper servers freshly.
    *
    * @param {PackageInfo[]} packagesInfo
-   * @returns {boolean} if any of components is already installed and the other is not installed
+   * @returns {boolean} true if any of components is already installed and the other is not installed
    *                    or the installed one has a newer version.
    */
   shouldUninstallServerPackages(packagesInfo = []) {
@@ -132,7 +132,7 @@ class UiAutomator2Server {
    * Checks if server components should be installed on the device under test in scope of the current driver session.
    *
    * @param {PackageInfo[]} packagesInfo
-   * @returns {boolean} if any of components is not installed or older than currently installed in order to
+   * @returns {boolean} true if any of components is not installed or older than currently installed in order to
    *                    install or upgrade the servers on the device under test.
    */
   shouldInstall(packagesInfo = []) {

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -106,14 +106,23 @@ class UiAutomator2Server {
 
   /**
    * If the given package information includes servers should uninstall befoer installing new UIA2 servers.
-   * For example, if the servers on the device is newer than servers UIA2 driver wants to use for the session.
+   * For example, if one of servers on the device was newer than servers current UIA2 driver wants to
+   * use for the session, the UIA2 driver should uninstall the installed ones in order to avoid
+   * version mismatch between the UIA2 drier and servers on the device.
+   * Also, if the device has missing servers, current UIA2 driver should uninstall all
+   * servers once in order to install proper servers freshly.
    *
    * @param {PackageInfo[]} packagesInfo
    * @returns {boolean}
    */
   shouldUninstallServerPackages(packagesInfo = []) {
-    return (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED)
-    && !packagesInfo.every(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED));
+    const isAnyComponentInstalled = packagesInfo.some(
+      ({installState}) => installState !== this.adb.APP_INSTALL_STATE.NOT_INSTALLED);
+    const isAnyComponentNotInstalledOrNewer = packagesInfo.some(({installState}) => [
+      /** @type {string} */ (this.adb.APP_INSTALL_STATE.NOT_INSTALLED),
+      /** @type {string} */ (this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED),
+    ].includes(installState));
+    return isAnyComponentInstalled && isAnyComponentNotInstalledOrNewer;
   }
 
   /**

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -116,8 +116,9 @@ class UiAutomator2Server {
     );
 
     this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
-    // Enforce server packages reinstall if any of the packages is not installed, while the other is
-    const shouldUninstallServerPackages = (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED)
+    // Enforce server packages reinstall if any of the packages is not installed,
+    // or newer one than uia2 driver is going to use.
+    const shouldUninstallServerPackages = (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED)
           && !packagesInfo.every(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED));
     // Install must always follow uninstall. Also, perform the install if
     // any of server packages is not installed or is outdated

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -129,10 +129,11 @@ class UiAutomator2Server {
   }
 
   /**
-   * If the given package information includes servers which can install with current UIA2 driver has.
+   * Checks if server components should be installed on the device under test in scope of the current driver session.
    *
    * @param {PackageInfo[]} packagesInfo
-   * @returns {boolean}
+   * @returns {boolean} if any of components is not installed or older than currently installed in order to
+   *                    install or upgrade the servers on the device under test.
    */
   shouldInstall(packagesInfo = []) {
     return packagesInfo.some(({installState}) => [

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -99,7 +99,7 @@ class UiAutomator2Server {
 
   /**
    * @typedef {Object} PackageInfo
-   * @property {string} installState
+   * @property {import('appium-adb/build/lib/tools/apk-utils').InstallState} installState
    * @property {string} appPath
    * @property {string} appId
    */
@@ -122,8 +122,8 @@ class UiAutomator2Server {
     const isAnyComponentInstalled = packagesInfo.some(
       ({installState}) => installState !== this.adb.APP_INSTALL_STATE.NOT_INSTALLED);
     const isAnyComponentNotInstalledOrNewer = packagesInfo.some(({installState}) => [
-      /** @type {string} */ (this.adb.APP_INSTALL_STATE.NOT_INSTALLED),
-      /** @type {string} */ (this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED),
+      this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
+      this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
     ].includes(installState));
     return isAnyComponentInstalled && isAnyComponentNotInstalledOrNewer;
   }
@@ -137,8 +137,8 @@ class UiAutomator2Server {
    */
   shouldInstallServerPackages(packagesInfo = []) {
     return packagesInfo.some(({installState}) => [
-      /** @type {string} */ (this.adb.APP_INSTALL_STATE.NOT_INSTALLED),
-      /** @type {string} */ (this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED),
+      this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
+      this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
     ].includes(installState));
   }
 
@@ -161,8 +161,6 @@ class UiAutomator2Server {
     );
 
     this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
-    // To ensure if the UIA2 driver should uninstall UI2 server packages from the device
-    // to use proper UIA2 server versions current UIA2 server wants to use.
     const shouldUninstallServerPackages = this.shouldUninstallServerPackages(packagesInfo);
     // Install must always follow uninstall. Also, perform the install if
     // any of server packages is not installed or is outdated

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -135,7 +135,7 @@ class UiAutomator2Server {
    * @returns {boolean} true if any of components is not installed or older than currently installed in order to
    *                    install or upgrade the servers on the device under test.
    */
-  shouldInstall(packagesInfo = []) {
+  shouldInstallServerPackages(packagesInfo = []) {
     return packagesInfo.some(({installState}) => [
       /** @type {string} */ (this.adb.APP_INSTALL_STATE.NOT_INSTALLED),
       /** @type {string} */ (this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED),
@@ -162,11 +162,11 @@ class UiAutomator2Server {
 
     this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
     // To ensure if the UIA2 driver should uninstall UI2 server packages from the device
-    // to use peoper UIA2 server versions current UIA2 server wants to use.
+    // to use proper UIA2 server versions current UIA2 server wants to use.
     const shouldUninstallServerPackages = this.shouldUninstallServerPackages(packagesInfo);
     // Install must always follow uninstall. Also, perform the install if
     // any of server packages is not installed or is outdated
-    const shouldInstallServerPackages = shouldUninstallServerPackages || this.shouldInstall(packagesInfo);
+    const shouldInstallServerPackages = shouldUninstallServerPackages || this.shouldInstallServerPackages(packagesInfo);
     this.log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
     if (shouldInstallServerPackages && shouldUninstallServerPackages) {
       this.log.info('Full packages reinstall is going to be performed');

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -131,7 +131,7 @@ class UiAutomator2Server {
    * @param {PackageInfo[]} packagesInfo
    * @returns {boolean}
    */
-  canInstallServerPackages (packagesInfo = []) {
+  shouldInstall(packagesInfo = []) {
     return packagesInfo.some(({installState}) => [
       /** @type {string} */ (this.adb.APP_INSTALL_STATE.NOT_INSTALLED),
       /** @type {string} */ (this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED),
@@ -157,12 +157,12 @@ class UiAutomator2Server {
     );
 
     this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
-    // Enforce server packages reinstall if any of the packages is not installed,
-    // or new server packages are newer than servers on the deivce.
+    // To ensure if the UIA2 driver should uninstall UI2 server packages from the device
+    // to use peoper UIA2 server versions current UIA2 server wants to use.
     const shouldUninstallServerPackages = this.shouldUninstallServerPackages(packagesInfo);
     // Install must always follow uninstall. Also, perform the install if
     // any of server packages is not installed or is outdated
-    const shouldInstallServerPackages = shouldUninstallServerPackages || this.canInstallServerPackages(packagesInfo);
+    const shouldInstallServerPackages = shouldUninstallServerPackages || this.shouldInstall(packagesInfo);
     this.log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
     if (shouldInstallServerPackages && shouldUninstallServerPackages) {
       this.log.info('Full packages reinstall is going to be performed');

--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -98,6 +98,32 @@ class UiAutomator2Server {
   }
 
   /**
+   * @typedef {Object} PackageInfo
+   * @property {string} installState
+   * @property {string} appPath
+   * @property {string} appId
+   */
+  /**
+   * @param {PackageInfo[]} packagesInfo
+   * @returns {boolean}
+   */
+  shouldUninstallServerPackages(packagesInfo = []) {
+    return (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED)
+    && !packagesInfo.every(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED));
+  }
+
+  /**
+   * @param {PackageInfo[]} packagesInfo
+   * @returns {boolean}
+   */
+  canInstallServerPackages (packagesInfo = []) {
+    return packagesInfo.some(({installState}) => [
+      /** @type {string} */ (this.adb.APP_INSTALL_STATE.NOT_INSTALLED),
+      /** @type {string} */ (this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED),
+    ].includes(installState));
+  }
+
+  /**
    * Installs the apks on to the device or emulator.
    *
    * @param {number} installTimeout - Installation timeout
@@ -117,15 +143,11 @@ class UiAutomator2Server {
 
     this.log.debug(`Server packages status: ${JSON.stringify(packagesInfo)}`);
     // Enforce server packages reinstall if any of the packages is not installed,
-    // or newer one than uia2 driver is going to use.
-    const shouldUninstallServerPackages = (packagesInfo.some(({installState}) => installState === this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED)
-          && !packagesInfo.every(({installState}) => installState === this.adb.APP_INSTALL_STATE.NOT_INSTALLED));
+    // or new server packages are newer than servers on the deivce.
+    const shouldUninstallServerPackages = this.shouldUninstallServerPackages(packagesInfo);
     // Install must always follow uninstall. Also, perform the install if
     // any of server packages is not installed or is outdated
-    const shouldInstallServerPackages = shouldUninstallServerPackages || packagesInfo.some(({installState}) => [
-      this.adb.APP_INSTALL_STATE.NOT_INSTALLED,
-      this.adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
-    ].includes(installState));
+    const shouldInstallServerPackages = shouldUninstallServerPackages || this.canInstallServerPackages(packagesInfo);
     this.log.info(`Server packages are ${shouldInstallServerPackages ? '' : 'not '}going to be (re)installed`);
     if (shouldInstallServerPackages && shouldUninstallServerPackages) {
       this.log.info('Full packages reinstall is going to be performed');

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -13,6 +13,182 @@ chai.use(chaiAsPromised);
 
 describe('UiAutomator2', function () {
   const adb = new ADB();
+
+  describe('shouldUninstallServerPackages', function () {
+    let uiautomator2;
+    const serverApk = {
+      'appPath': 'path/to/appium-uiautomator2-server.apk',
+      'appId': 'io.appium.uiautomator2.server'
+    };
+    const serverTestApk = {
+      'appPath': 'path/to/appium-uiautomator2-server-test.apk',
+      'appId': 'io.appium.uiautomator2.server.test'
+    };
+    beforeEach(function () {
+      uiautomator2 = new UiAutomator2Server(log, {
+        adb,
+        tmpDir: 'tmp',
+        systemPort: 4724,
+        host: 'localhost',
+        devicePort: 6790,
+        disableWindowAnimation: false,
+        disableSuppressAccessibilityService: false
+      });
+    });
+    it('with newer servers are installed', function () {
+      uiautomator2.shouldUninstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      ]).should.eql(true);
+    }),
+    it('with newer server is installed but the other could be old one', function () {
+      // Then, enforce to uninstall all apks
+      uiautomator2.shouldUninstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      ]).should.eql(true);
+    }),
+    it('with newer server is installed', function () {
+      uiautomator2.shouldUninstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      ]).should.eql(false);
+    }),
+    it('with older servers are installed', function () {
+      // then, installing newer serves are sufficient.
+      uiautomator2.shouldUninstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      ]).should.eql(false);
+    }),
+    it('with no server are installed', function () {
+      uiautomator2.shouldUninstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
+          'appPath': 'path/to/appium-uiautomator2-server.apk',
+          'appId': 'io.appium.uiautomator2.server'
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
+          'appPath': 'path/to/appium-uiautomator2-server-test.apk',
+          'appId': 'io.appium.uiautomator2.server.test'
+        }
+      ]).should.eql(false);
+    });
+  });
+
+  describe('canInstallServerPackages', function () {
+    let uiautomator2;
+    const serverApk = {
+      'appPath': 'path/to/appium-uiautomator2-server.apk',
+      'appId': 'io.appium.uiautomator2.server'
+    };
+    const serverTestApk = {
+      'appPath': 'path/to/appium-uiautomator2-server-test.apk',
+      'appId': 'io.appium.uiautomator2.server.test'
+    };
+    beforeEach(function () {
+      uiautomator2 = new UiAutomator2Server(log, {
+        adb,
+        tmpDir: 'tmp',
+        systemPort: 4724,
+        host: 'localhost',
+        devicePort: 6790,
+        disableWindowAnimation: false,
+        disableSuppressAccessibilityService: false
+      });
+    });
+    it('with newer servers are installed', function () {
+      uiautomator2.canInstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      // since installation may fail
+      ]).should.eql(false);
+    }),
+    it('with newer server is installed but the other could be old one', function () {
+      // Then, enforce to uninstall all apks
+      uiautomator2.canInstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      ]).should.eql(true);
+    }),
+    it('with newer server is installed', function () {
+      uiautomator2.canInstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      ]).should.eql(false);
+    }),
+    it('with older servers are installed', function () {
+      // then, installing newer serves are sufficient.
+      uiautomator2.canInstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          ...serverApk
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
+          ...serverTestApk
+        }
+      ]).should.eql(true);
+    }),
+    it('with no server are installed', function () {
+      uiautomator2.canInstallServerPackages([
+        {
+          'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
+          'appPath': 'path/to/appium-uiautomator2-server.apk',
+          'appId': 'io.appium.uiautomator2.server'
+        },
+        {
+          'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
+          'appPath': 'path/to/appium-uiautomator2-server-test.apk',
+          'appId': 'io.appium.uiautomator2.server.test'
+        }
+      ]).should.eql(true);
+    });
+  });
+
   describe('installServerApk', withMocks({adb, helpers}, (mocks) => {
     let uiautomator2;
     beforeEach(function () {
@@ -35,7 +211,7 @@ describe('UiAutomator2', function () {
 
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
-        .returns(adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED);
+        .returns(adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED);
 
       // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
@@ -58,7 +234,7 @@ describe('UiAutomator2', function () {
 
       // SERVER_PACKAGE_ID
       mocks.adb.expects('getApplicationInstallState').once()
-        .returns(adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED);
+        .returns(adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED);
 
       // SERVER_PACKAGE_ID and SERVER_TEST_PACKAGE_ID
       mocks.adb.expects('checkApkCert').twice().returns(true);
@@ -146,7 +322,6 @@ describe('UiAutomator2', function () {
         .once().returns(INSTRUMENTATION_TARGET);
       await uiautomator2.installServerApk();
     });
-
 
     it('a server is installed but server.test is not', async function () {
       mocks.helpers.expects('isWriteable').never();

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -22,7 +22,6 @@ describe('UiAutomator2', function () {
     'appPath': 'path/to/appium-uiautomator2-server-test.apk',
     'appId': 'io.appium.uiautomator2.server.test'
   };
-
   const defaultUIA2ServerOptions = {
     tmpDir: 'tmp',
     systemPort: 4724,

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -101,7 +101,7 @@ describe('UiAutomator2', function () {
     });
   });
 
-  describe('canInstallServerPackages', function () {
+  describe('shouldInstall', function () {
     let uiautomator2;
     const serverApk = {
       'appPath': 'path/to/appium-uiautomator2-server.apk',
@@ -123,7 +123,7 @@ describe('UiAutomator2', function () {
       });
     });
     it('with newer servers are installed', function () {
-      uiautomator2.canInstallServerPackages([
+      uiautomator2.shouldInstall([
         {
           'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
           ...serverApk
@@ -137,7 +137,7 @@ describe('UiAutomator2', function () {
     }),
     it('with newer server is installed but the other could be old one', function () {
       // Then, enforce to uninstall all apks
-      uiautomator2.canInstallServerPackages([
+      uiautomator2.shouldInstall([
         {
           'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
           ...serverApk
@@ -149,7 +149,7 @@ describe('UiAutomator2', function () {
       ]).should.eql(true);
     }),
     it('with newer server is installed', function () {
-      uiautomator2.canInstallServerPackages([
+      uiautomator2.shouldInstall([
         {
           'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
           ...serverApk
@@ -162,7 +162,7 @@ describe('UiAutomator2', function () {
     }),
     it('with older servers are installed', function () {
       // then, installing newer serves are sufficient.
-      uiautomator2.canInstallServerPackages([
+      uiautomator2.shouldInstall([
         {
           'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
           ...serverApk
@@ -174,7 +174,7 @@ describe('UiAutomator2', function () {
       ]).should.eql(true);
     }),
     it('with no server are installed', function () {
-      uiautomator2.canInstallServerPackages([
+      uiautomator2.shouldInstall([
         {
           'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
           'appPath': 'path/to/appium-uiautomator2-server.apk',

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -12,27 +12,29 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('UiAutomator2', function () {
+  let uiautomator2;
   const adb = new ADB();
+  const serverApk = {
+    'appPath': 'path/to/appium-uiautomator2-server.apk',
+    'appId': 'io.appium.uiautomator2.server'
+  };
+  const serverTestApk = {
+    'appPath': 'path/to/appium-uiautomator2-server-test.apk',
+    'appId': 'io.appium.uiautomator2.server.test'
+  };
+
+  const defaultUIA2ServerOptions = {
+    tmpDir: 'tmp',
+    systemPort: 4724,
+    host: 'localhost',
+    devicePort: 6790,
+    disableWindowAnimation: false
+  };
 
   describe('shouldUninstallServerPackages', function () {
-    let uiautomator2;
-    const serverApk = {
-      'appPath': 'path/to/appium-uiautomator2-server.apk',
-      'appId': 'io.appium.uiautomator2.server'
-    };
-    const serverTestApk = {
-      'appPath': 'path/to/appium-uiautomator2-server-test.apk',
-      'appId': 'io.appium.uiautomator2.server.test'
-    };
     beforeEach(function () {
       uiautomator2 = new UiAutomator2Server(log, {
-        adb,
-        tmpDir: 'tmp',
-        systemPort: 4724,
-        host: 'localhost',
-        devicePort: 6790,
-        disableWindowAnimation: false,
-        disableSuppressAccessibilityService: false
+        adb, ...defaultUIA2ServerOptions
       });
     });
     it('with newer servers are installed', function () {
@@ -102,24 +104,9 @@ describe('UiAutomator2', function () {
   });
 
   describe('shouldInstall', function () {
-    let uiautomator2;
-    const serverApk = {
-      'appPath': 'path/to/appium-uiautomator2-server.apk',
-      'appId': 'io.appium.uiautomator2.server'
-    };
-    const serverTestApk = {
-      'appPath': 'path/to/appium-uiautomator2-server-test.apk',
-      'appId': 'io.appium.uiautomator2.server.test'
-    };
     beforeEach(function () {
       uiautomator2 = new UiAutomator2Server(log, {
-        adb,
-        tmpDir: 'tmp',
-        systemPort: 4724,
-        host: 'localhost',
-        devicePort: 6790,
-        disableWindowAnimation: false,
-        disableSuppressAccessibilityService: false
+        adb, ...defaultUIA2ServerOptions
       });
     });
     it('with newer servers are installed', function () {
@@ -190,16 +177,9 @@ describe('UiAutomator2', function () {
   });
 
   describe('installServerApk', withMocks({adb, helpers}, (mocks) => {
-    let uiautomator2;
     beforeEach(function () {
       uiautomator2 = new UiAutomator2Server(log, {
-        adb,
-        tmpDir: 'tmp',
-        systemPort: 4724,
-        host: 'localhost',
-        devicePort: 6790,
-        disableWindowAnimation: false,
-        disableSuppressAccessibilityService: false
+        adb, ...defaultUIA2ServerOptions
       });
     });
     afterEach(function () {

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -47,7 +47,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(true);
+      ]).should.be.true;
     }),
     it('with newer server is installed but the other could be old one', function () {
       // Then, enforce to uninstall all apks
@@ -60,7 +60,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(true);
+      ]).should.be.true;
     }),
     it('with newer server is installed', function () {
       uiautomator2.shouldUninstallServerPackages([
@@ -72,7 +72,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(false);
+      ]).should.be.false;
     }),
     it('with older servers are installed', function () {
       // then, installing newer serves are sufficient.
@@ -85,7 +85,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(false);
+      ]).should.be.false;
     }),
     it('with no server are installed', function () {
       uiautomator2.shouldUninstallServerPackages([
@@ -97,7 +97,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(false);
+      ]).should.be.false;
     });
   });
 
@@ -118,7 +118,7 @@ describe('UiAutomator2', function () {
           ...serverTestApk
         }
       // since installation may fail
-      ]).should.eql(false);
+      ]).should.be.false;
     }),
     it('with newer server is installed but the other could be old one', function () {
       // Then, enforce to uninstall all apks
@@ -131,7 +131,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(true);
+      ]).should.be.true;
     }),
     it('with newer server is installed', function () {
       uiautomator2.shouldInstallServerPackages([
@@ -143,7 +143,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(false);
+      ]).should.be.false;
     }),
     it('with older servers are installed', function () {
       // then, installing newer serves are sufficient.
@@ -156,7 +156,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(true);
+      ]).should.be.true;
     }),
     it('with no server are installed', function () {
       uiautomator2.shouldInstallServerPackages([
@@ -168,7 +168,7 @@ describe('UiAutomator2', function () {
           'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
           ...serverTestApk
         }
-      ]).should.eql(true);
+      ]).should.be.true;
     });
   });
 

--- a/test/unit/uiautomator2-specs.js
+++ b/test/unit/uiautomator2-specs.js
@@ -91,26 +91,24 @@ describe('UiAutomator2', function () {
       uiautomator2.shouldUninstallServerPackages([
         {
           'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
-          'appPath': 'path/to/appium-uiautomator2-server.apk',
-          'appId': 'io.appium.uiautomator2.server'
+          ...serverApk
         },
         {
           'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
-          'appPath': 'path/to/appium-uiautomator2-server-test.apk',
-          'appId': 'io.appium.uiautomator2.server.test'
+          ...serverTestApk
         }
       ]).should.eql(false);
     });
   });
 
-  describe('shouldInstall', function () {
+  describe('shouldInstallServerPackages', function () {
     beforeEach(function () {
       uiautomator2 = new UiAutomator2Server(log, {
         adb, ...defaultUIA2ServerOptions
       });
     });
     it('with newer servers are installed', function () {
-      uiautomator2.shouldInstall([
+      uiautomator2.shouldInstallServerPackages([
         {
           'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
           ...serverApk
@@ -124,7 +122,7 @@ describe('UiAutomator2', function () {
     }),
     it('with newer server is installed but the other could be old one', function () {
       // Then, enforce to uninstall all apks
-      uiautomator2.shouldInstall([
+      uiautomator2.shouldInstallServerPackages([
         {
           'installState': adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED,
           ...serverApk
@@ -136,7 +134,7 @@ describe('UiAutomator2', function () {
       ]).should.eql(true);
     }),
     it('with newer server is installed', function () {
-      uiautomator2.shouldInstall([
+      uiautomator2.shouldInstallServerPackages([
         {
           'installState': adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED,
           ...serverApk
@@ -149,7 +147,7 @@ describe('UiAutomator2', function () {
     }),
     it('with older servers are installed', function () {
       // then, installing newer serves are sufficient.
-      uiautomator2.shouldInstall([
+      uiautomator2.shouldInstallServerPackages([
         {
           'installState': adb.APP_INSTALL_STATE.OLDER_VERSION_INSTALLED,
           ...serverApk
@@ -161,16 +159,14 @@ describe('UiAutomator2', function () {
       ]).should.eql(true);
     }),
     it('with no server are installed', function () {
-      uiautomator2.shouldInstall([
+      uiautomator2.shouldInstallServerPackages([
         {
           'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
-          'appPath': 'path/to/appium-uiautomator2-server.apk',
-          'appId': 'io.appium.uiautomator2.server'
+          ...serverApk
         },
         {
           'installState': adb.APP_INSTALL_STATE.NOT_INSTALLED,
-          'appPath': 'path/to/appium-uiautomator2-server-test.apk',
-          'appId': 'io.appium.uiautomator2.server.test'
+          ...serverTestApk
         }
       ]).should.eql(true);
     });


### PR DESCRIPTION
https://github.com/appium/appium/issues/19799#issuecomment-2181932720

The current UIA2 driver does not uninstall UIA2 servers on the device if they are newer than newly installed servers by the UIA2. It could cause old UIA2 driver with newer UIA2 servers on the device, which is a mismatch condition. It could cause unexpected behavior.
 
Maybe... `this.adb.APP_INSTALL_STATE.NOT_INSTALLED` condition should be `this.adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED` to "uninstall" installed UIA2 servers?


It looks like `sinon` mock's `expects`, `never`, once etc might not be so reliable. Some could be not good. To improve condition check as test code, I have extracted condition check into two methods and added tests for them. At least `shouldUninstallServerPackages` and `canInstallServerPackages` tests should be reliable.