### PR TITLE
fix: stop io.appium.uiautomator2.server process as well (in cleanupAutomationLeftovers)

### DIFF
--- a/lib/uiautomator2.js
+++ b/lib/uiautomator2.js
@@ -413,7 +413,10 @@ class UiAutomator2Server {
     }
 
     try {
-      await this.adb.forceStop(SERVER_TEST_PACKAGE_ID);
+      await B.all([
+        this.adb.forceStop(SERVER_PACKAGE_ID),
+        this.adb.forceStop(SERVER_TEST_PACKAGE_ID)
+      ]);
     } catch (ignore) {}
     if (strictCleanup) {
       // https://github.com/appium/appium/issues/10749


### PR DESCRIPTION
More tuning fix for https://github.com/appium/appium-uiautomator2-driver/pull/655 

I observed that to ensure that the `/status` endpoint stops, we should kill the `io.appium.uiautomator2.server` process as well in addition to `io.appium.uiautomator2.server.test`. Only `.test` process kill keep responding to the `/status`. So as `cleanupAutomationLeftovers`, it would be reasonable to stop both processes
(this behavior finding is an edge case in my another issue investigation though)