### PR TITLE
chore: allow compatibility with appium 3 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "xpath": "^0.x"
   },
   "peerDependencies": {
-    "appium": "^2.4.1"
+    "appium": "^2.4.1 || ^3.0.0-beta.0"
   },
   "engines": {
     "node": ">=14",


### PR DESCRIPTION
since this driver is used as part of appium's smoke tests, the appium 3 branch tests won't pass until we ensure compatibility with appium 3 :-/ 