### PR TITLE
fix: Make package parameter of deep link command optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Start URI that may take users directly to the specific content in the app. Read 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
 url | string | yes | The URL to start | theapp://login/
-package | string | no | The name of the package to start the URI with | 'com.mycompany'
+package | string | no | The name of the package to start the URI with. This argument was required previously but became optional since version 3.9.3 | 'com.mycompany'
 waitForLaunch | boolean | no | If `false` then ADB won't wait for the started activity to return the control. `true` by default | false
 
 ### mobile: startLogsBroadcast

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Start URI that may take users directly to the specific content in the app. Read 
 Name | Type | Required | Description | Example
 --- | --- | --- | --- | ---
 url | string | yes | The URL to start | theapp://login/
-package | string | yes | The name of the package to start the URI with | 'com.mycompany'
+package | string | no | The name of the package to start the URI with | 'com.mycompany'
 waitForLaunch | boolean | no | If `false` then ADB won't wait for the started activity to return the control. `true` by default | false
 
 ### mobile: startLogsBroadcast

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -93,7 +93,7 @@ export interface DeepLinkOpts {
   /**
    * The name of the package to start the URI with.
    */
-  package: string;
+  package?: string;
   /**
    * If `false` then adb won't wait for the started activity to return the control.
    * @defaultValue true

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "appium-adb": "^12.7.0",
+    "appium-adb": "^12.7.3",
     "appium-android-driver": "^9.14.2",
     "appium-uiautomator2-server": "^7.0.24",
     "asyncbox": "^3.0.0",


### PR DESCRIPTION
`pkg` parameter of `startUri()` becomes optional from appium-adb 12.7.3 by https://github.com/appium/appium-adb/pull/776.

This PR follows this change by making `package` parameter of `mobileDeepLink()` optional.