### PR TITLE
fix: Tune retrieval of package launch info

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -671,9 +671,13 @@ class AndroidUiautomator2Driver
       ...caps,
       ...sessionInfo,
     };
-    // Adding AUT package name in the capabilities if package name not exist in caps
-    if (!capsWithSessionInfo.appPackage && appInfo) {
-      capsWithSessionInfo.appPackage = appInfo.appPackage;
+    // Adding AUT info in the capabilities if it does not exist in caps
+    if (appInfo) {
+      for (const capName of ['appPackage', 'appActivity']) {
+        if (!capsWithSessionInfo[capName] && appInfo[capName]) {
+          capsWithSessionInfo[capName] = appInfo[capName];
+        }
+      }
     }
 
     await this.performSessionExecution(capsWithSessionInfo);

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "appium-adb": "^12.7.3",
-    "appium-android-driver": "^9.14.7",
+    "appium-android-driver": "^9.14.9",
     "appium-uiautomator2-server": "^7.0.24",
     "asyncbox": "^3.0.0",
     "axios": "^1.6.5",


### PR DESCRIPTION
Based on https://github.com/appium/appium-android-driver/pull/975