### PR TITLE
test: update README Development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2018,7 +2018,7 @@ def test_edit_text(driver):
 
 ```
 npm install appium-uiautomator2-driver
-npm run watch
+npm run dev
 ```
 
 Unit tests:
@@ -2030,5 +2030,9 @@ npm run test
 Functional tests:
 
 ```
-npm run e2e-test
+npm run e2e-test:commands
+npm run e2e-test:commands:find
+npm run e2e-test:commands:general
+npm run e2e-test:commands:keyboard
+npm run e2e-test:driver
 ```


### PR DESCRIPTION
I was trying to run a custom driver locally and noticed the commands were not up-to-date: `npm run watch` didn't work and neither did the e2e-test command

- `npm run dev` seems to be the new short for `npm run build -- --watch`
- I didn't find a single command to run all flavors of e2e-tests so I listed all of them