### PR TITLE
ci: run with Android 16 also

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -18,6 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - apiLevel: 36
+          emuTag: google_apis
+          arch: x86_64
         - apiLevel: 32
           emuTag: google_apis
           arch: x86_64


### PR DESCRIPTION
To run with the latest Beta

The test execution speed seems similar to the existing API level 28, so I think it makes sense to enable API level 36 for upcoming Android 16 testing as well.