### PR TITLE
docs: fix endpoint for "mobile: startLogsBroadcast"

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ waitForLaunch | boolean | no | If `false` then ADB won't wait for the started ac
 
 ### mobile: startLogsBroadcast
 
-Starts Android logcat broadcast websocket on the same host and port where Appium server is running at `/ws/session/:sessionId:/appium/logcat` endpoint. The method will return immediately if the web socket is already listening. Each connected webcoket listener will receive logcat log lines as soon as they are visible to Appium. Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://appiumpro.com/editions/55-using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) for more details.
+Starts Android logcat broadcast websocket on the same host and port where Appium server is running at `/ws/session/:sessionId:/appium/device/logcat` endpoint. The method will return immediately if the web socket is already listening. Each connected websocket listener will receive logcat log lines as soon as they are visible to Appium. Read [Using Mobile Execution Commands to Continuously Stream Device Logs with Appium](https://appiumpro.com/editions/55-using-mobile-execution-commands-to-continuously-stream-device-logs-with-appium) for more details.
 
 Consider using [logs broadcast via BiDi](./docs/bidi.md#logentryadded) over this extension.
 


### PR DESCRIPTION
### What’s Changed

- Fixed a typo in the README: “webcoket listener” → “websocket listener”
- Corrected the documented WebSocket endpoint for logcat broadcasting:  
  `/ws/session/:sessionId:/appium/logcat` → `/ws/session/:sessionId:/appium/device/logcat`
- The new path reflects the actual behavior of Appium as observed in runtime logs.

### Reference

> Did not match the websocket upgrade request at  
> `/ws/session/<sessionId>/appium/logcat` to any known route

> [AndroidUiautomator2Driver] Starting logcat broadcasting on web socket server  
> `{"address":"0.0.0.0","family":"IPv4","port":4723}`  
> to `/ws/session/8f8b8d76-53c0-4ca9-87ef-4a1281e3e4fc/appium/device/logcat`
