### PR TITLE
chore: remove no reference dev deps rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.0.1",
     "prettier": "^3.0.3",
-    "rimraf": "^5.0.0",
     "semantic-release": "^24.0.0",
     "sharp": "^0.x",
     "sinon": "^21.0.0",


### PR DESCRIPTION
```
kazu $ git grep 'rimraf'
package.json:    "rimraf": "^5.0.0",
```

instead of https://github.com/appium/appium-uiautomator2-driver/pull/805