### PR TITLE
chore: Set minimum axios dependency version to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "appium-android-driver": "^13.1.1",
     "appium-uiautomator2-server": "^9.11.1",
     "asyncbox": "^6.0.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "bluebird": "^3.5.1",
     "css-selector-parser": "^3.0.0",
     "io.appium.settings": "^7.0.1",


### PR DESCRIPTION
This pull request updates a dependency in the `package.json` file to keep the project up-to-date with the latest features and security patches.

Dependency updates:

* Upgraded the `axios` package from version `1.13.5` to `1.15.0` in `package.json`.