### PR TITLE
chore: downgrade conventional-changelog-conventionalcommits to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@xmldom/xmldom": "^0.x",
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "prettier": "^3.0.3",
     "semantic-release": "^25.0.2",
     "sharp": "^0.x",


### PR DESCRIPTION
https://github.com/appium/appium-safari-driver/pull/177