### PR TITLE
fix: stop using deprecated appium/support imageUtil, rely on local sharp

### DIFF
--- a/lib/commands/screenshot.ts
+++ b/lib/commands/screenshot.ts
@@ -1,8 +1,7 @@
 import type {StringRecord} from '@appium/types';
-import {imageUtil} from 'appium/support.js';
 
 import type {AndroidUiautomator2Driver} from '../driver.js';
-import {isEmpty} from '../utils/index.js';
+import {cropBase64Image, isEmpty} from '../utils/index.js';
 import type {Screenshot} from './types.js';
 
 // Matches SurfaceFlinger output format:
@@ -57,7 +56,7 @@ export async function mobileViewportScreenshot(this: AndroidUiautomator2Driver):
 export async function getViewportScreenshot(this: AndroidUiautomator2Driver): Promise<string> {
   const screenshot = await this.getScreenshot();
   const rect = await this.getViewPortRect();
-  return await imageUtil.cropBase64Image(screenshot, rect);
+  return await cropBase64Image(screenshot, rect);
 }
 
 /**

--- a/lib/utils/image.ts
+++ b/lib/utils/image.ts
@@ -1,0 +1,41 @@
+import type sharp from 'sharp';
+import type {Region} from 'sharp';
+
+let sharpModule: typeof sharp | null = null;
+
+/**
+ * Lazily imports the optional `sharp` dependency.
+ *
+ * @returns The sharp module for image processing
+ */
+export async function requireSharp(): Promise<typeof sharp> {
+  if (sharpModule) {
+    return sharpModule;
+  }
+  try {
+    sharpModule = (await import('sharp')).default;
+    return sharpModule;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Cannot load the 'sharp' module needed for image processing. ` +
+        `Consider visiting https://sharp.pixelplumbing.com/install for troubleshooting. ` +
+        `Original error: ${message}`,
+      {cause: err},
+    );
+  }
+}
+
+/**
+ * Crops the image by the given rectangle (base64 string in, base64 string out).
+ *
+ * @param base64Image The string with base64 encoded image.
+ * Supports all image formats natively supported by Sharp library.
+ * @param region The selected region of the image
+ * @returns base64 encoded string of the cropped image
+ */
+export async function cropBase64Image(base64Image: string, region: Region): Promise<string> {
+  const sharpInstance = await requireSharp();
+  const buf = await sharpInstance(Buffer.from(base64Image, 'base64')).extract(region).toBuffer();
+  return buf.toString('base64');
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export {signApp} from './app.js';
+export {cropBase64Image, requireSharp} from './image.js';
 export {escapeRegExp, isEmpty} from './lang.js';
 export {memoize} from './memoize.js';
 export {MJpegStream} from './mjpeg.js';

--- a/lib/utils/mjpeg.ts
+++ b/lib/utils/mjpeg.ts
@@ -2,7 +2,8 @@ import {Transform, Writable, type Readable, type TransformCallback, type Writabl
 
 import {logger} from 'appium/support.js';
 import axios from 'axios';
-import type sharp from 'sharp';
+
+import {requireSharp} from './image.js';
 
 const log = logger.getLogger('MJPEG');
 
@@ -94,26 +95,6 @@ export class MjpegFrameParser extends Transform {
     this.buffer = null;
     this.expectedLength = 0;
     this.bytesWritten = 0;
-  }
-}
-
-let sharpModule: typeof sharp | null = null;
-
-async function requireSharp(): Promise<typeof sharp> {
-  if (sharpModule) {
-    return sharpModule;
-  }
-  try {
-    sharpModule = (await import('sharp')).default;
-    return sharpModule;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `Cannot load the 'sharp' module needed for MJPEG frame processing. ` +
-        `Consider visiting https://sharp.pixelplumbing.com/install for troubleshooting. ` +
-        `Original error: ${message}`,
-      {cause: err},
-    );
   }
 }
 


### PR DESCRIPTION
Replaces imageUtil.cropBase64Image() in screenshot.ts with a local implementation in lib/utils/image.ts, and dedupes mjpeg.ts's own inline requireSharp() to use the same shared helper.