### PR TITLE
test: skip flaky webview context suite on API 26 CI emulator

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -116,6 +116,7 @@ jobs:
       name: e2e_api${{ matrix.apiLevel }}_batch${{ matrix.batch }}
       env:
         E2E_BATCH: ${{ matrix.batch }}
+        E2E_API_LEVEL: ${{ matrix.apiLevel }}
       with:
         script: bash -xe scripts/run-functional-tests.sh
         avd-name: ${{ env.ANDROID_AVD }}

--- a/test/functional/commands/general/context-e2e-specs.ts
+++ b/test/functional/commands/general/context-e2e-specs.ts
@@ -4,6 +4,7 @@ import {describe, it, before, after, afterEach} from 'node:test';
 import type {Browser} from 'webdriverio';
 
 import {APIDEMOS_CAPS, amendCapabilities} from '../../desired.js';
+import {isCiApiLevel} from '../../helpers/ci-e2e.js';
 import {initSession, deleteSession} from '../../helpers/session.js';
 
 const WEBVIEW = 'WEBVIEW_io.appium.android.apis';
@@ -11,7 +12,8 @@ const NATIVE = 'NATIVE_APP';
 const NATIVE_LOCATOR = "//*[@class='android.widget.TextView']";
 const WEBVIEW_LOCATOR = "//*[text()='This page is a Selenium sandbox']";
 
-describe('apidemo - context', function () {
+// WebView1 activity reliably times out to launch on the API 26 CI emulator (no hw acceleration).
+describe('apidemo - context', {skip: isCiApiLevel(26)}, function () {
   describe('general', function () {
     let driver: Browser;
     before(async function () {

--- a/test/functional/helpers/ci-e2e.ts
+++ b/test/functional/helpers/ci-e2e.ts
@@ -1,3 +1,7 @@
 export function isCi(): boolean {
   return Boolean(process.env.CI);
 }
+
+export function isCiApiLevel(apiLevel: number): boolean {
+  return isCi() && process.env.E2E_API_LEVEL === String(apiLevel);
+}


### PR DESCRIPTION
WebView1 activity reliably times out to launch on the API 26 emulator runner (no hardware acceleration), failing the apidemo - context suite. Thread the API level through as E2E_API_LEVEL so the skip only applies there, not on newer API levels where the suite passes.