### PR TITLE
test: serve drag and drop page locally instead of an external site

### DIFF
--- a/test/functional/assets/drag-and-drop.html
+++ b/test/functional/assets/drag-and-drop.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Drag and Drop</title>
+  <style>
+    .columns {
+      width: 400px;
+    }
+    .column {
+      height: 150px;
+      width: 150px;
+      float: left;
+      border: 2px solid #666666;
+      background-color: #ccc;
+      margin-right: 5px;
+      text-align: center;
+      cursor: move;
+    }
+    .column.over {
+      border: 2px dashed #000;
+    }
+  </style>
+</head>
+<body>
+  <div class="example">
+    <h3>Drag and Drop</h3>
+    <div id="columns">
+      <div class="column" id="column-a" draggable="true"><header>A</header></div>
+      <div class="column" id="column-b" draggable="true"><header>B</header></div>
+    </div>
+  </div>
+  <script>
+    // Mirrors the-internet.herokuapp.com/drag_and_drop's native HTML5 drag-and-drop
+    // behavior (dragstart/dragenter/dragover/dragleave/drop/dragend).
+    var dragSrcEl = null;
+
+    function handleDragStart(e) {
+      this.style.opacity = '0.4';
+
+      dragSrcEl = this;
+
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/html', this.innerHTML);
+    }
+
+    function handleDragOver(e) {
+      if (e.preventDefault) {
+        e.preventDefault();
+      }
+
+      e.dataTransfer.dropEffect = 'move';
+
+      return false;
+    }
+
+    function handleDragEnter(e) {
+      this.classList.add('over');
+    }
+
+    function handleDragLeave(e) {
+      this.classList.remove('over');
+    }
+
+    function handleDrop(e) {
+      if (e.stopPropagation) {
+        e.stopPropagation();
+      }
+
+      if (dragSrcEl != this) {
+        dragSrcEl.innerHTML = this.innerHTML;
+        this.innerHTML = e.dataTransfer.getData('text/html');
+      }
+
+      return false;
+    }
+
+    function handleDragEnd(e) {
+      [].forEach.call(cols, function (col) {
+        col.classList.remove('over');
+      });
+      this.style.opacity = '1';
+    }
+
+    var cols = document.querySelectorAll('#columns .column');
+    [].forEach.call(cols, function (col) {
+      col.addEventListener('dragstart', handleDragStart, false);
+      col.addEventListener('dragenter', handleDragEnter, false);
+      col.addEventListener('dragover', handleDragOver, false);
+      col.addEventListener('dragleave', handleDragLeave, false);
+      col.addEventListener('drop', handleDrop, false);
+      col.addEventListener('dragend', handleDragEnd, false);
+    });
+  </script>
+</body>
+</html>

--- a/test/functional/commands/find/by-image-e2e-specs.ts
+++ b/test/functional/commands/find/by-image-e2e-specs.ts
@@ -1,26 +1,16 @@
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import {describe, it, before, after} from 'node:test';
-import {fileURLToPath} from 'node:url';
 
-import {node} from 'appium/support.js';
 import {sleep} from 'asyncbox';
 import type {Browser} from 'webdriverio';
 
 import {APIDEMOS_CAPS, amendCapabilities} from '../../desired.js';
+import {getAssetPath} from '../../helpers/fixtures.js';
 import {initSession, deleteSession} from '../../helpers/session.js';
 
-const MODULE_NAME = 'appium-uiautomator2-driver';
-const FILENAME = fileURLToPath(import.meta.url);
-const MODULE_ROOT = node.getModuleRootSync(MODULE_NAME, FILENAME);
-if (!MODULE_ROOT) {
-  throw new Error(`Cannot find the root folder of the ${MODULE_NAME} Node.js module`);
-}
-
-const ASSETS_DIR = path.resolve(MODULE_ROOT, 'test', 'functional', 'assets');
-const START_IMG = path.resolve(ASSETS_DIR, 'start-button.png');
-const STOP_IMG = path.resolve(ASSETS_DIR, 'stop-button.png');
-const SQUARES_IMG = path.resolve(ASSETS_DIR, 'checkered-squares.png');
+const START_IMG = getAssetPath('start-button.png');
+const STOP_IMG = getAssetPath('stop-button.png');
+const SQUARES_IMG = getAssetPath('checkered-squares.png');
 
 describe('Find - Image', {skip: true}, function () {
   let driver: Browser;

--- a/test/functional/commands/general/actions-e2e-specs.ts
+++ b/test/functional/commands/general/actions-e2e-specs.ts
@@ -1,24 +1,16 @@
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import {describe, it, before, after} from 'node:test';
-import {fileURLToPath} from 'node:url';
 
 import {ADB} from 'appium-adb';
-import {node} from 'appium/support.js';
 import type {Browser} from 'webdriverio';
 
 import {BROWSER_CAPS} from '../../desired.js';
 import {isCi} from '../../helpers/ci-e2e.js';
+import {getAssetPath} from '../../helpers/fixtures.js';
 import {startLocalPageServer, type LocalPageServer} from '../../helpers/local-page-server.js';
 import {initSession, deleteSession} from '../../helpers/session.js';
 
-const MODULE_NAME = 'appium-uiautomator2-driver';
-const FILENAME = fileURLToPath(import.meta.url);
-const MODULE_ROOT = node.getModuleRootSync(MODULE_NAME, FILENAME);
-if (!MODULE_ROOT) {
-  throw new Error(`Cannot find the root folder of the ${MODULE_NAME} Node.js module`);
-}
-const DRAG_AND_DROP_PAGE = path.resolve(MODULE_ROOT, 'test', 'functional', 'assets', 'drag-and-drop.html');
+const DRAG_AND_DROP_PAGE = getAssetPath('drag-and-drop.html');
 
 describe('w3c actions - webview', {skip: isCi()}, function () {
   let driver: Browser | undefined;

--- a/test/functional/commands/general/actions-e2e-specs.ts
+++ b/test/functional/commands/general/actions-e2e-specs.ts
@@ -1,15 +1,28 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import {describe, it, before, after} from 'node:test';
+import {fileURLToPath} from 'node:url';
 
 import {ADB} from 'appium-adb';
+import {node} from 'appium/support.js';
 import type {Browser} from 'webdriverio';
 
 import {BROWSER_CAPS} from '../../desired.js';
 import {isCi} from '../../helpers/ci-e2e.js';
+import {startLocalPageServer, type LocalPageServer} from '../../helpers/local-page-server.js';
 import {initSession, deleteSession} from '../../helpers/session.js';
+
+const MODULE_NAME = 'appium-uiautomator2-driver';
+const FILENAME = fileURLToPath(import.meta.url);
+const MODULE_ROOT = node.getModuleRootSync(MODULE_NAME, FILENAME);
+if (!MODULE_ROOT) {
+  throw new Error(`Cannot find the root folder of the ${MODULE_NAME} Node.js module`);
+}
+const DRAG_AND_DROP_PAGE = path.resolve(MODULE_ROOT, 'test', 'functional', 'assets', 'drag-and-drop.html');
 
 describe('w3c actions - webview', {skip: isCi()}, function () {
   let driver: Browser | undefined;
+  let pageServer: LocalPageServer | undefined;
 
   before(async function () {
     const adb = new ADB();
@@ -18,8 +31,12 @@ describe('w3c actions - webview', {skip: isCi()}, function () {
       return;
     }
     driver = await initSession(BROWSER_CAPS);
+    pageServer = await startLocalPageServer(adb, DRAG_AND_DROP_PAGE);
   });
   after(async function () {
+    if (pageServer) {
+      await pageServer.close();
+    }
     if (driver) {
       await deleteSession();
     }
@@ -40,7 +57,7 @@ describe('w3c actions - webview', {skip: isCi()}, function () {
       // ignore
     }
 
-    await driver!.url('https://the-internet.herokuapp.com/drag_and_drop');
+    await driver!.url(pageServer!.url);
 
     // confirm the driver actually proxied us into the Chrome web content and not native context;
     // a pure browserName session reports 'CHROMIUM', an app's embedded webview reports 'WEBVIEW_<pkg>'

--- a/test/functional/helpers/fixtures.ts
+++ b/test/functional/helpers/fixtures.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {node} from 'appium/support.js';
+
+const MODULE_NAME = 'appium-uiautomator2-driver';
+
+let assetsDir: string | undefined;
+
+/**
+ * Resolves the `test/functional/assets` fixtures directory of this module on disk,
+ * regardless of whether the caller runs from source or from the compiled `build/` output.
+ */
+export function getAssetsDir(): string {
+  if (!assetsDir) {
+    const filename = fileURLToPath(import.meta.url);
+    const moduleRoot = node.getModuleRootSync(MODULE_NAME, filename);
+    if (!moduleRoot) {
+      throw new Error(`Cannot find the root folder of the ${MODULE_NAME} Node.js module`);
+    }
+    assetsDir = path.resolve(moduleRoot, 'test', 'functional', 'assets');
+  }
+  return assetsDir;
+}
+
+/** Resolves a path to a fixture file under `test/functional/assets`. */
+export function getAssetPath(...segments: string[]): string {
+  return path.resolve(getAssetsDir(), ...segments);
+}

--- a/test/functional/helpers/local-page-server.ts
+++ b/test/functional/helpers/local-page-server.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs/promises';
+import http from 'node:http';
+
+import type {ADB} from 'appium-adb';
+
+import {getFreePort} from './ports.js';
+
+export type LocalPageServer = {
+  url: string;
+  close: () => Promise<void>;
+};
+
+/**
+ * Serves a single static HTML file on 127.0.0.1 and makes it reachable from the
+ * Android device under test at the same port via `adb reverse`, so tests do not
+ * depend on an external web page being online.
+ */
+export async function startLocalPageServer(adb: ADB, filePath: string): Promise<LocalPageServer> {
+  const content = await fs.readFile(filePath);
+  const port = await getFreePort();
+
+  const server = http.createServer((_req, res) => {
+    res.setHeader('Content-Type', 'text/html');
+    res.end(content);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => resolve());
+  });
+
+  await adb.reversePort(port, port);
+
+  return {
+    url: `http://127.0.0.1:${port}/`,
+    close: async () => {
+      try {
+        await adb.removePortReverse(port);
+      } catch {
+        // ignore
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}


### PR DESCRIPTION
The W3C actions drag-and-drop test navigated to the-internet.herokuapp.com, making it fail whenever that external page is unreachable. Clone the page locally and serve it over adb reverse, similar to how xcuitest-driver uses its guinea pig pages.
